### PR TITLE
Added many plots support and bounds input

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ npm run build-purescript
 
 ## Run project
 ```sh
-npm run start
+npm start
 ```
 This will start the web page as a server that can be accessed via `http://localhost:1234/`
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ It should also be mentioned that the PS can be build alone using
 npm run build-purescript
 ```
 
+## Run project
+```sh
+npm run start
+```
+This will start the web page as a server that can be accessed via `http://localhost:1234/`
+
 ## Run tests
 ```sh
 npm run test

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "install": "spago install",
     "build": "npm run build-purescript && parcel build index.html",
-    "server": "npm run build-purescript && parcel index.html",
+    "start": "npm run build-purescript && parcel index.html",
     "build-purescript": "spago build",
     "test": "spago test --main Test.Main"
   },

--- a/spago.dhall
+++ b/spago.dhall
@@ -12,6 +12,7 @@
   , "parsing"
   , "rationals"
   , "quickcheck-combinators"
+  , "numbers"
   ]
 , packages = ./packages.dhall
 , sources = [ "src/**/*.purs", "test/**/*.purs" ]

--- a/src/Components/BoundsInput/BoundsInput.purs
+++ b/src/Components/BoundsInput/BoundsInput.purs
@@ -1,7 +1,7 @@
 module Components.BoundsInput where
 
 import Prelude
-import Components.ExpressionInput.Controller (ExpressionInputController)
+
 import Data.Maybe (Maybe(..), fromMaybe)
 import Data.Number (fromString)
 import Effect.Class (class MonadEffect)
@@ -41,15 +41,15 @@ data Action
   | HandleInput Bound String
   | Update
 
-expressionInputComponent :: forall query m. MonadEffect m => ExpressionInputController -> H.Component HH.HTML query XYBounds BoundsInputMessage m
-expressionInputComponent controller =
+boundsInputComponent :: forall query m. MonadEffect m => H.Component HH.HTML query XYBounds BoundsInputMessage m
+boundsInputComponent =
   H.mkComponent
     { initialState: initialState
     , render
     , eval:
         H.mkEval
           $ H.defaultEval
-              { handleAction = handleAction controller
+              { handleAction = handleAction
               , receive = Just <<< Recieve
               , initialize = Just Init
               }
@@ -80,33 +80,37 @@ render state =
         , HP.value state.xBounds.lower
         , HP.id_ "xLower"
         ]
+    , HH.br_
     , HH.label
         [ HP.for "xUpper" ]
         [ HH.text "Upper X:" ]
     , HH.input
         [ HP.type_ HP.InputText
-        , HE.onValueChange $ toValueChangeActionEvent XLower
-        , HP.value state.xBounds.lower
+        , HE.onValueChange $ toValueChangeActionEvent XUpper
+        , HP.value state.xBounds.upper
         , HP.id_ "xUpper"
         ]
+    , HH.br_
     , HH.label
         [ HP.for "yLower" ]
         [ HH.text "Lower Y:" ]
     , HH.input
         [ HP.type_ HP.InputText
-        , HE.onValueChange $ toValueChangeActionEvent XLower
-        , HP.value state.xBounds.lower
+        , HE.onValueChange $ toValueChangeActionEvent YLower
+        , HP.value state.yBounds.lower
         , HP.id_ "yLower"
         ]
+    , HH.br_
     , HH.label
         [ HP.for "yUpper" ]
         [ HH.text "Upper Y:" ]
     , HH.input
         [ HP.type_ HP.InputText
-        , HE.onValueChange $ toValueChangeActionEvent XLower
-        , HP.value state.xBounds.lower
+        , HE.onValueChange $ toValueChangeActionEvent YUpper
+        , HP.value state.yBounds.upper
         , HP.id_ "yUpper"
         ]
+    , HH.br_
     , HH.button
         [ HE.onClick $ toActionEvent Update ]
         [ HH.text "Update" ]
@@ -120,15 +124,14 @@ toValueChangeActionEvent bound value = Just $ HandleInput bound value
 toActionEvent :: forall a. Action -> a -> Maybe Action
 toActionEvent action _ = Just action
 
-handleAction :: forall m. MonadEffect m => ExpressionInputController -> Action -> H.HalogenM State Action () BoundsInputMessage m Unit
-handleAction controller = case _ of
+handleAction :: forall m. MonadEffect m => Action -> H.HalogenM State Action () BoundsInputMessage m Unit
+handleAction = case _ of
   Init -> do
     { xBounds, yBounds } <- H.get
-    handleAction controller (HandleInput XLower $ xBounds.lower)
-    handleAction controller (HandleInput XUpper $ xBounds.upper)
-    handleAction controller (HandleInput YLower $ yBounds.lower)
-    handleAction controller (HandleInput YUpper $ yBounds.upper)
-    pure unit
+    handleAction (HandleInput XLower $ xBounds.lower)
+    handleAction (HandleInput XUpper $ xBounds.upper)
+    handleAction (HandleInput YLower $ yBounds.lower)
+    handleAction (HandleInput YUpper $ yBounds.upper)
   HandleInput XLower stringInput -> H.modify_ _ { xBounds { lower = stringInput } }
   HandleInput XUpper stringInput -> H.modify_ _ { xBounds { upper = stringInput } }
   HandleInput YLower stringInput -> H.modify_ _ { yBounds { lower = stringInput } }

--- a/src/Components/BoundsInput/BoundsInput.purs
+++ b/src/Components/BoundsInput/BoundsInput.purs
@@ -1,0 +1,166 @@
+module Components.BoundsInput where
+
+import Prelude
+import Components.ExpressionInput.Controller (ExpressionInputController)
+import Data.Maybe (Maybe(..), fromMaybe)
+import Data.Number (fromString)
+import Effect.Class (class MonadEffect)
+import Halogen as H
+import Halogen.HTML as HH
+import Halogen.HTML.Events as HE
+import Halogen.HTML.Properties as HP
+import Types (XYBounds)
+
+type BoundsInputSlot p
+  = forall q. H.Slot q BoundsInputMessage p
+
+type State
+  = { error :: Maybe String
+    , xBounds ::
+        { upper :: String
+        , lower :: String
+        }
+    , yBounds ::
+        { upper :: String
+        , lower :: String
+        }
+    }
+
+data Bound
+  = XLower
+  | XUpper
+  | YLower
+  | YUpper
+
+data BoundsInputMessage
+  = Updated XYBounds
+
+data Action
+  = Init
+  | Recieve XYBounds
+  | HandleInput Bound String
+  | Update
+
+expressionInputComponent :: forall query m. MonadEffect m => ExpressionInputController -> H.Component HH.HTML query XYBounds BoundsInputMessage m
+expressionInputComponent controller =
+  H.mkComponent
+    { initialState: initialState
+    , render
+    , eval:
+        H.mkEval
+          $ H.defaultEval
+              { handleAction = handleAction controller
+              , receive = Just <<< Recieve
+              , initialize = Just Init
+              }
+    }
+
+initialState :: XYBounds -> State
+initialState input =
+  { error: Nothing
+  , xBounds:
+      { upper: show input.xBounds.upper
+      , lower: show input.xBounds.lower
+      }
+  , yBounds:
+      { upper: show input.yBounds.upper
+      , lower: show input.yBounds.lower
+      }
+  }
+
+render :: forall slots m. State -> HH.ComponentHTML Action slots m
+render state =
+  HH.div_
+    [ HH.label
+        [ HP.for "xLower" ]
+        [ HH.text "Lower X:" ]
+    , HH.input
+        [ HP.type_ HP.InputText
+        , HE.onValueChange $ toValueChangeActionEvent XLower
+        , HP.value state.xBounds.lower
+        , HP.id_ "xLower"
+        ]
+    , HH.label
+        [ HP.for "xUpper" ]
+        [ HH.text "Upper X:" ]
+    , HH.input
+        [ HP.type_ HP.InputText
+        , HE.onValueChange $ toValueChangeActionEvent XLower
+        , HP.value state.xBounds.lower
+        , HP.id_ "xUpper"
+        ]
+    , HH.label
+        [ HP.for "yLower" ]
+        [ HH.text "Lower Y:" ]
+    , HH.input
+        [ HP.type_ HP.InputText
+        , HE.onValueChange $ toValueChangeActionEvent XLower
+        , HP.value state.xBounds.lower
+        , HP.id_ "yLower"
+        ]
+    , HH.label
+        [ HP.for "yUpper" ]
+        [ HH.text "Upper Y:" ]
+    , HH.input
+        [ HP.type_ HP.InputText
+        , HE.onValueChange $ toValueChangeActionEvent XLower
+        , HP.value state.xBounds.lower
+        , HP.id_ "yUpper"
+        ]
+    , HH.button
+        [ HE.onClick $ toActionEvent Update ]
+        [ HH.text "Update" ]
+    , HH.p_
+        [ HH.text $ fromMaybe "" state.error ]
+    ]
+
+toValueChangeActionEvent :: Bound -> String -> Maybe Action
+toValueChangeActionEvent bound value = Just $ HandleInput bound value
+
+toActionEvent :: forall a. Action -> a -> Maybe Action
+toActionEvent action _ = Just action
+
+handleAction :: forall m. MonadEffect m => ExpressionInputController -> Action -> H.HalogenM State Action () BoundsInputMessage m Unit
+handleAction controller = case _ of
+  Init -> do
+    { xBounds, yBounds } <- H.get
+    handleAction controller (HandleInput XLower $ xBounds.lower)
+    handleAction controller (HandleInput XUpper $ xBounds.upper)
+    handleAction controller (HandleInput YLower $ yBounds.lower)
+    handleAction controller (HandleInput YUpper $ yBounds.upper)
+    pure unit
+  HandleInput XLower stringInput -> H.modify_ _ { xBounds { lower = stringInput } }
+  HandleInput XUpper stringInput -> H.modify_ _ { xBounds { upper = stringInput } }
+  HandleInput YLower stringInput -> H.modify_ _ { yBounds { lower = stringInput } }
+  HandleInput YUpper stringInput -> H.modify_ _ { yBounds { upper = stringInput } }
+  Recieve bounds ->
+    H.modify_
+      _
+        { xBounds
+          { upper = show bounds.xBounds.upper
+          , lower = show bounds.xBounds.lower
+          }
+        , yBounds
+          { upper = show bounds.yBounds.upper
+          , lower = show bounds.yBounds.lower
+          }
+        }
+  Update -> do
+    { xBounds, yBounds } <- H.get
+    let
+      maybeXLower = fromString xBounds.lower
+
+      maybeXUpper = fromString xBounds.upper
+
+      maybeYLower = fromString yBounds.lower
+
+      maybeYUpper = fromString yBounds.upper
+    case maybeXLower of
+      Nothing -> H.modify_ _ { error = Just $ "Failed to parse lower X bound" }
+      Just xLower -> case maybeXUpper of
+        Nothing -> H.modify_ _ { error = Just $ "Failed to parse upper X bound" }
+        Just xUpper -> case maybeYLower of
+          Nothing -> H.modify_ _ { error = Just $ "Failed to parse lower Y bound" }
+          Just yLower -> case maybeYUpper of
+            Nothing -> H.modify_ _ { error = Just $ "Failed to parse upper Y bound" }
+            Just yUpper -> H.raise (Updated { xBounds: { lower: xLower, upper: xUpper }, yBounds: { lower: yLower, upper: yUpper } })

--- a/src/Components/Canvas/Draw.purs
+++ b/src/Components/Canvas/Draw.purs
@@ -6,9 +6,10 @@ import Data.Array (head, tail)
 import Data.Maybe (fromMaybe)
 import Data.String (joinWith)
 import Data.Traversable (for_)
+import Draw.Color (Color, rgba)
 import Effect (Effect)
 import Graphics.Canvas (LineCap(..), beginPath, clearRect, fill, fillText, lineTo, moveTo, setFillStyle, setFont, setLineCap, setLineDash, setLineWidth, setStrokeStyle, stroke)
-import Types (Polygon, Position, Color)
+import Types (Polygon, Position)
 
 -- | Draws text
 drawText :: String -> Number -> Position -> DrawOperation
@@ -17,9 +18,9 @@ drawText text size { x, y } =
     let
       font = joinWith " " [ show size <> "px", "Arial" ]
 
-      color = { r: 0.0, g: 0.0, b: 0.0, a: 1.0 }
+      color = rgba 0.0 0.0 0.0 1.0 
     setFont drawContext.context font
-    setFillStyle drawContext.context $ toColorString color
+    setFillStyle drawContext.context $ show color
     fillText drawContext.context text x y
 
 clearCanvas :: DrawOperation
@@ -33,13 +34,13 @@ drawLine isDashed color { x: x1, y: y1 } { x: x2, y: y2 } =
     beginPath drawContext.context
     moveTo drawContext.context x1 y1
     lineTo drawContext.context x2 y2
-    setStrokeStyle drawContext.context $ toColorString color
+    setStrokeStyle drawContext.context $ show color
     when isDashed do
       setLineDash drawContext.context [ 1.0, 3.0 ]
     stroke drawContext.context
 
 drawPlotLine :: Position -> Position -> DrawOperation
-drawPlotLine = drawLine false { r: 0.0, g: 0.0, b: 0.0, a: 1.0 }
+drawPlotLine = drawLine false $ rgba 0.0 0.0 0.0 1.0 
 
 drawXAxisLine :: Number -> Number -> DrawOperation
 drawXAxisLine xZero range drawContext = drawPlotLine a b drawContext
@@ -66,7 +67,7 @@ drawXGridLine x value range drawContext = do
   where
   relativeX = (x * drawContext.canvasWidth) / range
 
-  color = { r: 0.0, g: 0.0, b: 0.0, a: 0.3 }
+  color = rgba 0.0 0.0 0.0 0.3 
 
 drawYGridLine :: Number -> Number -> Number -> DrawOperation
 drawYGridLine y value range drawContext = do
@@ -75,7 +76,7 @@ drawYGridLine y value range drawContext = do
   where
   relativeY = drawContext.canvasHeight - ((y * drawContext.canvasHeight) / range)
 
-  color = { r: 0.0, g: 0.0, b: 0.0, a: 0.3 }
+  color = rgba 0.0 0.0 0.0 0.3 
 
 drawPolygon :: Polygon -> DrawOperation
 drawPolygon [] drawContext = pure unit
@@ -96,11 +97,11 @@ drawEnclosure :: Boolean -> Array Polygon -> DrawOperation
 drawEnclosure isSelected polygons =
   withLocalDrawContext \drawContext -> do
     if isSelected then do
-      setFillStyle drawContext.context $ toColorString { r: 255.0, g: 192.0, b: 203.0, a: 0.7 }
-      setStrokeStyle drawContext.context $ toColorString { r: 0.0, g: 0.0, b: 0.0, a: 1.0 }
+      setFillStyle drawContext.context $ show $ rgba 255.0 192.0 203.0 0.7
+      setStrokeStyle drawContext.context $ show $ rgba 0.0 0.0 0.0 1.0
     else do
-      setFillStyle drawContext.context $ toColorString { r: 255.0, g: 192.0, b: 203.0, a: 0.4 }
-      setStrokeStyle drawContext.context $ toColorString { r: 0.0, g: 0.0, b: 0.0, a: 0.7 }
+      setFillStyle drawContext.context $ show $ rgba 255.0 192.0 203.0 0.4
+      setStrokeStyle drawContext.context $ show $ rgba 0.0 0.0 0.0 0.7
     for_ polygons (\polygon -> drawPolygon polygon drawContext)
 
 drawRootEnclosure :: Number -> Number -> Number -> DrawOperation
@@ -111,11 +112,8 @@ drawRootEnclosure yZero l r =
     lineTo drawContext.context r yZero
     setLineWidth drawContext.context 5.0
     setLineCap drawContext.context Round
-    setStrokeStyle drawContext.context $ toColorString { r: 255.0, g: 0.0, b: 0.0, a: 1.0 }
+    setStrokeStyle drawContext.context $ show $ rgba 255.0 0.0 0.0 1.0
     stroke drawContext.context
 
 origin :: Position
 origin = { x: 0.0, y: 0.0 }
-
-toColorString :: Color -> String
-toColorString { r, g, b, a } = "rgb(" <> (show r) <> "," <> (show g) <> "," <> (show b) <> "," <> (show a) <> ")"

--- a/src/Components/Canvas/Draw.purs
+++ b/src/Components/Canvas/Draw.purs
@@ -8,7 +8,7 @@ import Data.String (joinWith)
 import Data.Traversable (for_)
 import Effect (Effect)
 import Graphics.Canvas (LineCap(..), beginPath, clearRect, fill, fillText, lineTo, moveTo, setFillStyle, setFont, setLineCap, setLineDash, setLineWidth, setStrokeStyle, stroke)
-import Types (Polygon, Position, RGBA)
+import Types (Polygon, Position, Color)
 
 -- | Draws text
 drawText :: String -> Number -> Position -> DrawOperation
@@ -27,7 +27,7 @@ clearCanvas =
   withLocalDrawContext \drawContext -> do
     clearRect drawContext.context { height: drawContext.canvasHeight, width: drawContext.canvasWidth, x: 0.0, y: 0.0 }
 
-drawLine :: Boolean -> RGBA -> Position -> Position -> DrawOperation
+drawLine :: Boolean -> Color -> Position -> Position -> DrawOperation
 drawLine isDashed color { x: x1, y: y1 } { x: x2, y: y2 } =
   withLocalDrawContext \drawContext -> do
     beginPath drawContext.context
@@ -117,5 +117,5 @@ drawRootEnclosure yZero l r =
 origin :: Position
 origin = { x: 0.0, y: 0.0 }
 
-toColorString :: RGBA -> String
+toColorString :: Color -> String
 toColorString { r, g, b, a } = "rgb(" <> (show r) <> "," <> (show g) <> "," <> (show b) <> "," <> (show a) <> ")"

--- a/src/Components/Canvas/Draw.purs
+++ b/src/Components/Canvas/Draw.purs
@@ -1,14 +1,14 @@
 module Components.Canvas.Draw where
 
 import Prelude
-import Data.Traversable (for_)
+import Components.Canvas.Context (DrawOperation, withLocalDrawContext)
 import Data.Array (head, tail)
 import Data.Maybe (fromMaybe)
 import Data.String (joinWith)
+import Data.Traversable (for_)
 import Effect (Effect)
 import Graphics.Canvas (LineCap(..), beginPath, clearRect, fill, fillText, lineTo, moveTo, setFillStyle, setFont, setLineCap, setLineDash, setLineWidth, setStrokeStyle, stroke)
-import Types (Position, Polygon)
-import Components.Canvas.Context (DrawOperation, withLocalDrawContext)
+import Types (Polygon, Position, RGBA)
 
 -- | Draws text
 drawText :: String -> Number -> Position -> DrawOperation
@@ -16,10 +16,10 @@ drawText text size { x, y } =
   withLocalDrawContext \drawContext -> do
     let
       font = joinWith " " [ show size <> "px", "Arial" ]
-    -- Set up the context for drawing the text
+
+      color = { r: 0.0, g: 0.0, b: 0.0, a: 1.0 }
     setFont drawContext.context font
-    setFillStyle drawContext.context "#000000"
-    -- Draw the text
+    setFillStyle drawContext.context $ toColorString color
     fillText drawContext.context text x y
 
 clearCanvas :: DrawOperation
@@ -27,60 +27,68 @@ clearCanvas =
   withLocalDrawContext \drawContext -> do
     clearRect drawContext.context { height: drawContext.canvasHeight, width: drawContext.canvasWidth, x: 0.0, y: 0.0 }
 
-drawLine :: Boolean -> Position -> Position -> DrawOperation
-drawLine isDashed { x: x1, y: y1 } { x: x2, y: y2 } =
+drawLine :: Boolean -> RGBA -> Position -> Position -> DrawOperation
+drawLine isDashed color { x: x1, y: y1 } { x: x2, y: y2 } =
   withLocalDrawContext \drawContext -> do
     beginPath drawContext.context
     moveTo drawContext.context x1 y1
     lineTo drawContext.context x2 y2
+    setStrokeStyle drawContext.context $ toColorString color
     when isDashed do
       setLineDash drawContext.context [ 1.0, 3.0 ]
-      setStrokeStyle drawContext.context $ toRGBA 0.0 0.0 0.0 0.3
     stroke drawContext.context
 
 drawPlotLine :: Position -> Position -> DrawOperation
-drawPlotLine = drawLine false
+drawPlotLine = drawLine false { r: 0.0, g: 0.0, b: 0.0, a: 1.0 }
 
 drawXAxisLine :: Number -> Number -> DrawOperation
 drawXAxisLine xZero range drawContext = drawPlotLine a b drawContext
   where
-    relativeX = (xZero * drawContext.canvasWidth) / range
-    a = { x: relativeX, y: 0.0 }
-    b = { x: relativeX, y: drawContext.canvasHeight }
+  relativeX = (xZero * drawContext.canvasWidth) / range
+
+  a = { x: relativeX, y: 0.0 }
+
+  b = { x: relativeX, y: drawContext.canvasHeight }
 
 drawYAxisLine :: Number -> Number -> DrawOperation
 drawYAxisLine yZero range drawContext = drawPlotLine a b drawContext
   where
-    relativeY = drawContext.canvasHeight - (yZero * drawContext.canvasHeight) / range
-    a = { x: 0.0, y: relativeY }
-    b = { x: drawContext.canvasWidth, y: relativeY }
+  relativeY = drawContext.canvasHeight - (yZero * drawContext.canvasHeight) / range
+
+  a = { x: 0.0, y: relativeY }
+
+  b = { x: drawContext.canvasWidth, y: relativeY }
 
 drawXGridLine :: Number -> Number -> Number -> DrawOperation
 drawXGridLine x value range drawContext = do
-  drawLine true { x: relativeX, y: 0.0 } { x: relativeX, y: drawContext.canvasHeight } drawContext
+  drawLine true color { x: relativeX, y: 0.0 } { x: relativeX, y: drawContext.canvasHeight } drawContext
   drawText (show value) 10.0 { x: relativeX, y: drawContext.canvasHeight - 12.0 } drawContext
   where
   relativeX = (x * drawContext.canvasWidth) / range
 
+  color = { r: 0.0, g: 0.0, b: 0.0, a: 0.3 }
+
 drawYGridLine :: Number -> Number -> Number -> DrawOperation
 drawYGridLine y value range drawContext = do
-  drawLine true { x: 0.0, y: relativeY } { x: drawContext.canvasWidth, y: relativeY } drawContext
+  drawLine true color { x: 0.0, y: relativeY } { x: drawContext.canvasWidth, y: relativeY } drawContext
   drawText (show value) 10.0 { x: drawContext.canvasWidth - 40.0, y: relativeY } drawContext
   where
   relativeY = drawContext.canvasHeight - ((y * drawContext.canvasHeight) / range)
+
+  color = { r: 0.0, g: 0.0, b: 0.0, a: 0.3 }
 
 drawPolygon :: Polygon -> DrawOperation
 drawPolygon [] drawContext = pure unit
 
 drawPolygon points drawContext = do
-  let
-    { x: x1, y: y1 } = fromMaybe origin $ head points
   beginPath drawContext.context
   moveTo drawContext.context x1 y1
   for_ (fromMaybe [] (tail points)) drawPolygonLine
   fill drawContext.context
   stroke drawContext.context
   where
+  { x: x1, y: y1 } = fromMaybe origin $ head points
+
   drawPolygonLine :: Position -> Effect Unit
   drawPolygonLine { x: xi, y: yi } = lineTo drawContext.context xi yi
 
@@ -88,11 +96,11 @@ drawEnclosure :: Boolean -> Array Polygon -> DrawOperation
 drawEnclosure isSelected polygons =
   withLocalDrawContext \drawContext -> do
     if isSelected then do
-      setFillStyle drawContext.context $ toRGBA 255.0 192.0 203.0 0.7
-      setStrokeStyle drawContext.context $ toRGBA 0.0 0.0 0.0 1.0
+      setFillStyle drawContext.context $ toColorString { r: 255.0, g: 192.0, b: 203.0, a: 0.7 }
+      setStrokeStyle drawContext.context $ toColorString { r: 0.0, g: 0.0, b: 0.0, a: 1.0 }
     else do
-      setFillStyle drawContext.context $ toRGBA 255.0 192.0 2013.0 0.4
-      setStrokeStyle drawContext.context $ toRGBA 0.0 0.0 0.0 0.7
+      setFillStyle drawContext.context $ toColorString { r: 255.0, g: 192.0, b: 203.0, a: 0.4 }
+      setStrokeStyle drawContext.context $ toColorString { r: 0.0, g: 0.0, b: 0.0, a: 0.7 }
     for_ polygons (\polygon -> drawPolygon polygon drawContext)
 
 drawRootEnclosure :: Number -> Number -> Number -> DrawOperation
@@ -103,11 +111,11 @@ drawRootEnclosure yZero l r =
     lineTo drawContext.context r yZero
     setLineWidth drawContext.context 5.0
     setLineCap drawContext.context Round
-    setStrokeStyle drawContext.context $ toRGBA 255.0 0.0 0.0 1.0
+    setStrokeStyle drawContext.context $ toColorString { r: 255.0, g: 0.0, b: 0.0, a: 1.0 }
     stroke drawContext.context
 
 origin :: Position
 origin = { x: 0.0, y: 0.0 }
 
-toRGBA :: Number -> Number -> Number -> Number -> String
-toRGBA r g b a = "rgb(" <> (show r) <> "," <> (show g) <> "," <> (show b) <> "," <> (show a) <> ")"
+toColorString :: RGBA -> String
+toColorString { r, g, b, a } = "rgb(" <> (show r) <> "," <> (show g) <> "," <> (show b) <> "," <> (show a) <> ")"

--- a/src/Draw/Color.purs
+++ b/src/Draw/Color.purs
@@ -1,0 +1,22 @@
+module Draw.Color where
+
+import Prelude
+
+data Color
+  = RGBA
+    { r :: Number
+    , g :: Number
+    , b :: Number
+    , a :: Number
+    }
+  | HexCode String
+
+instance colorShow :: Show Color where
+  show (RGBA { r, g, b, a }) = "rgb(" <> (show r) <> "," <> (show g) <> "," <> (show b) <> "," <> (show a) <> ")"
+  show (HexCode code) = code
+
+rgba :: Number -> Number -> Number -> Number -> Color
+rgba r g b a = RGBA { r, g, b, a }
+
+hexCode :: String -> Color
+hexCode code = HexCode code

--- a/src/Draw/Color.purs
+++ b/src/Draw/Color.purs
@@ -1,4 +1,10 @@
-module Draw.Color where
+module Draw.Color
+  ( Color(..)
+  , rgba
+  , hexCode
+  , NamedColor(..)
+  , fromNamedColor
+  ) where
 
 import Prelude
 
@@ -10,13 +16,466 @@ data Color
     , a :: Number
     }
   | HexCode String
+  | NamedColor NamedColor
 
 instance colorShow :: Show Color where
   show (RGBA { r, g, b, a }) = "rgb(" <> (show r) <> "," <> (show g) <> "," <> (show b) <> "," <> (show a) <> ")"
   show (HexCode code) = code
+  show (NamedColor colorName) = colorToCode colorName
 
 rgba :: Number -> Number -> Number -> Number -> Color
 rgba r g b a = RGBA { r, g, b, a }
 
 hexCode :: String -> Color
 hexCode code = HexCode code
+
+fromNamedColor :: NamedColor -> Color
+fromNamedColor = NamedColor
+
+data NamedColor
+  = AliceBlue
+  | AntiqueWhite
+  | Aqua
+  | Aquamarine
+  | Azure
+  | Beige
+  | Bisque
+  | Black
+  | BlanchedAlmond
+  | Blue
+  | BlueViolet
+  | Brown
+  | BurlyWood
+  | CadetBlue
+  | Chartreuse
+  | Chocolate
+  | Coral
+  | CornflowerBlue
+  | Cornsilk
+  | Crimson
+  | Cyan
+  | DarkBlue
+  | DarkCyan
+  | DarkGoldenRod
+  | DarkGray
+  | DarkGrey
+  | DarkGreen
+  | DarkKhaki
+  | DarkMagenta
+  | DarkOliveGreen
+  | DarkOrange
+  | DarkOrchid
+  | DarkRed
+  | DarkSalmon
+  | DarkSeaGreen
+  | DarkSlateBlue
+  | DarkSlateGray
+  | DarkSlateGrey
+  | DarkTurquoise
+  | DarkViolet
+  | DeepPink
+  | DeepSkyBlue
+  | DimGray
+  | DimGrey
+  | DodgerBlue
+  | FireBrick
+  | FloralWhite
+  | ForestGreen
+  | Fuchsia
+  | Gainsboro
+  | GhostWhite
+  | Gold
+  | GoldenRod
+  | Gray
+  | Grey
+  | Green
+  | GreenYellow
+  | HoneyDew
+  | HotPink
+  | IndianRed
+  | Indigo
+  | Ivory
+  | Khaki
+  | Lavender
+  | LavenderBlush
+  | LawnGreen
+  | LemonChiffon
+  | LightBlue
+  | LightCoral
+  | LightCyan
+  | LightGoldenRodYellow
+  | LightGray
+  | LightGrey
+  | LightGreen
+  | LightPink
+  | LightSalmon
+  | LightSeaGreen
+  | LightSkyBlue
+  | LightSlateGray
+  | LightSlateGrey
+  | LightSteelBlue
+  | LightYellow
+  | Lime
+  | LimeGreen
+  | Linen
+  | Magenta
+  | Maroon
+  | MediumAquaMarine
+  | MediumBlue
+  | MediumOrchid
+  | MediumPurple
+  | MediumSeaGreen
+  | MediumSlateBlue
+  | MediumSpringGreen
+  | MediumTurquoise
+  | MediumVioletRed
+  | MidnightBlue
+  | MintCream
+  | MistyRose
+  | Moccasin
+  | NavajoWhite
+  | Navy
+  | OldLace
+  | Olive
+  | OliveDrab
+  | Orange
+  | OrangeRed
+  | Orchid
+  | PaleGoldenRod
+  | PaleGreen
+  | PaleTurquoise
+  | PaleVioletRed
+  | PapayaWhip
+  | PeachPuff
+  | Peru
+  | Pink
+  | Plum
+  | PowderBlue
+  | Purple
+  | RebeccaPurple
+  | Red
+  | RosyBrown
+  | RoyalBlue
+  | SaddleBrown
+  | Salmon
+  | SandyBrown
+  | SeaGreen
+  | SeaShell
+  | Sienna
+  | Silver
+  | SkyBlue
+  | SlateBlue
+  | SlateGray
+  | SlateGrey
+  | Snow
+  | SpringGreen
+  | SteelBlue
+  | Tan
+  | Teal
+  | Thistle
+  | Tomato
+  | Turquoise
+  | Violet
+  | Wheat
+  | White
+  | WhiteSmoke
+  | Yellow
+  | YellowGreen
+
+-- | Converts a `Color` into its associated HexCode
+colorToCode :: NamedColor -> String
+colorToCode AliceBlue = "#F0F8FF"
+
+colorToCode AntiqueWhite = "#FAEBD7"
+
+colorToCode Aqua = "#00FFFF"
+
+colorToCode Aquamarine = "#7FFFD4"
+
+colorToCode Azure = "#F0FFFF"
+
+colorToCode Beige = "#F5F5DC"
+
+colorToCode Bisque = "#FFE4C4"
+
+colorToCode Black = "#000000"
+
+colorToCode BlanchedAlmond = "#FFEBCD"
+
+colorToCode Blue = "#0000FF"
+
+colorToCode BlueViolet = "#8A2BE2"
+
+colorToCode Brown = "#A52A2A"
+
+colorToCode BurlyWood = "#DEB887"
+
+colorToCode CadetBlue = "#5F9EA0"
+
+colorToCode Chartreuse = "#7FFF00"
+
+colorToCode Chocolate = "#D2691E"
+
+colorToCode Coral = "#FF7F50"
+
+colorToCode CornflowerBlue = "#6495ED"
+
+colorToCode Cornsilk = "#FFF8DC"
+
+colorToCode Crimson = "#DC143C"
+
+colorToCode Cyan = "#00FFFF"
+
+colorToCode DarkBlue = "#00008B"
+
+colorToCode DarkCyan = "#008B8B"
+
+colorToCode DarkGoldenRod = "#B8860B"
+
+colorToCode DarkGray = "#A9A9A9"
+
+colorToCode DarkGrey = "#A9A9A9"
+
+colorToCode DarkGreen = "#006400"
+
+colorToCode DarkKhaki = "#BDB76B"
+
+colorToCode DarkMagenta = "#8B008B"
+
+colorToCode DarkOliveGreen = "#556B2F"
+
+colorToCode DarkOrange = "#FF8C00"
+
+colorToCode DarkOrchid = "#9932CC"
+
+colorToCode DarkRed = "#8B0000"
+
+colorToCode DarkSalmon = "#E9967A"
+
+colorToCode DarkSeaGreen = "#8FBC8F"
+
+colorToCode DarkSlateBlue = "#483D8B"
+
+colorToCode DarkSlateGray = "#2F4F4F"
+
+colorToCode DarkSlateGrey = "#2F4F4F"
+
+colorToCode DarkTurquoise = "#00CED1"
+
+colorToCode DarkViolet = "#9400D3"
+
+colorToCode DeepPink = "#FF1493"
+
+colorToCode DeepSkyBlue = "#00BFFF"
+
+colorToCode DimGray = "#696969"
+
+colorToCode DimGrey = "#696969"
+
+colorToCode DodgerBlue = "#1E90FF"
+
+colorToCode FireBrick = "#B22222"
+
+colorToCode FloralWhite = "#FFFAF0"
+
+colorToCode ForestGreen = "#228B22"
+
+colorToCode Fuchsia = "#FF00FF"
+
+colorToCode Gainsboro = "#DCDCDC"
+
+colorToCode GhostWhite = "#F8F8FF"
+
+colorToCode Gold = "#FFD700"
+
+colorToCode GoldenRod = "#DAA520"
+
+colorToCode Gray = "#808080"
+
+colorToCode Grey = "#808080"
+
+colorToCode Green = "#008000"
+
+colorToCode GreenYellow = "#ADFF2F"
+
+colorToCode HoneyDew = "#F0FFF0"
+
+colorToCode HotPink = "#FF69B4"
+
+colorToCode IndianRed = "#CD5C5C"
+
+colorToCode Indigo = "#4B0082"
+
+colorToCode Ivory = "#FFFFF0"
+
+colorToCode Khaki = "#F0E68C"
+
+colorToCode Lavender = "#E6E6FA"
+
+colorToCode LavenderBlush = "#FFF0F5"
+
+colorToCode LawnGreen = "#7CFC00"
+
+colorToCode LemonChiffon = "#FFFACD"
+
+colorToCode LightBlue = "#ADD8E6"
+
+colorToCode LightCoral = "#F08080"
+
+colorToCode LightCyan = "#E0FFFF"
+
+colorToCode LightGoldenRodYellow = "#FAFAD2"
+
+colorToCode LightGray = "#D3D3D3"
+
+colorToCode LightGrey = "#D3D3D3"
+
+colorToCode LightGreen = "#90EE90"
+
+colorToCode LightPink = "#FFB6C1"
+
+colorToCode LightSalmon = "#FFA07A"
+
+colorToCode LightSeaGreen = "#20B2AA"
+
+colorToCode LightSkyBlue = "#87CEFA"
+
+colorToCode LightSlateGray = "#778899"
+
+colorToCode LightSlateGrey = "#778899"
+
+colorToCode LightSteelBlue = "#B0C4DE"
+
+colorToCode LightYellow = "#FFFFE0"
+
+colorToCode Lime = "#00FF00"
+
+colorToCode LimeGreen = "#32CD32"
+
+colorToCode Linen = "#FAF0E6"
+
+colorToCode Magenta = "#FF00FF"
+
+colorToCode Maroon = "#800000"
+
+colorToCode MediumAquaMarine = "#66CDAA"
+
+colorToCode MediumBlue = "#0000CD"
+
+colorToCode MediumOrchid = "#BA55D3"
+
+colorToCode MediumPurple = "#9370DB"
+
+colorToCode MediumSeaGreen = "#3CB371"
+
+colorToCode MediumSlateBlue = "#7B68EE"
+
+colorToCode MediumSpringGreen = "#00FA9A"
+
+colorToCode MediumTurquoise = "#48D1CC"
+
+colorToCode MediumVioletRed = "#C71585"
+
+colorToCode MidnightBlue = "#191970"
+
+colorToCode MintCream = "#F5FFFA"
+
+colorToCode MistyRose = "#FFE4E1"
+
+colorToCode Moccasin = "#FFE4B5"
+
+colorToCode NavajoWhite = "#FFDEAD"
+
+colorToCode Navy = "#000080"
+
+colorToCode OldLace = "#FDF5E6"
+
+colorToCode Olive = "#808000"
+
+colorToCode OliveDrab = "#6B8E23"
+
+colorToCode Orange = "#FFA500"
+
+colorToCode OrangeRed = "#FF4500"
+
+colorToCode Orchid = "#DA70D6"
+
+colorToCode PaleGoldenRod = "#EEE8AA"
+
+colorToCode PaleGreen = "#98FB98"
+
+colorToCode PaleTurquoise = "#AFEEEE"
+
+colorToCode PaleVioletRed = "#DB7093"
+
+colorToCode PapayaWhip = "#FFEFD5"
+
+colorToCode PeachPuff = "#FFDAB9"
+
+colorToCode Peru = "#CD853F"
+
+colorToCode Pink = "#FFC0CB"
+
+colorToCode Plum = "#DDA0DD"
+
+colorToCode PowderBlue = "#B0E0E6"
+
+colorToCode Purple = "#800080"
+
+colorToCode RebeccaPurple = "#663399"
+
+colorToCode Red = "#FF0000"
+
+colorToCode RosyBrown = "#BC8F8F"
+
+colorToCode RoyalBlue = "#4169E1"
+
+colorToCode SaddleBrown = "#8B4513"
+
+colorToCode Salmon = "#FA8072"
+
+colorToCode SandyBrown = "#F4A460"
+
+colorToCode SeaGreen = "#2E8B57"
+
+colorToCode SeaShell = "#FFF5EE"
+
+colorToCode Sienna = "#A0522D"
+
+colorToCode Silver = "#C0C0C0"
+
+colorToCode SkyBlue = "#87CEEB"
+
+colorToCode SlateBlue = "#6A5ACD"
+
+colorToCode SlateGray = "#708090"
+
+colorToCode SlateGrey = "#708090"
+
+colorToCode Snow = "#FFFAFA"
+
+colorToCode SpringGreen = "#00FF7F"
+
+colorToCode SteelBlue = "#4682B4"
+
+colorToCode Tan = "#D2B48C"
+
+colorToCode Teal = "#008080"
+
+colorToCode Thistle = "#D8BFD8"
+
+colorToCode Tomato = "#FF6347"
+
+colorToCode Turquoise = "#40E0D0"
+
+colorToCode Violet = "#EE82EE"
+
+colorToCode Wheat = "#F5DEB3"
+
+colorToCode White = "#FFFFFF"
+
+colorToCode WhiteSmoke = "#F5F5F5"
+
+colorToCode Yellow = "#FFFF00"
+
+colorToCode YellowGreen = "#9ACD32"

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -58,7 +58,7 @@ data Action
   | HandleExpressionInput ExpressionInputMessage
   | HandleScroll H.SubscriptionId WheelEvent
   | HandleCanvas CanvasMessage
-  | Add
+  | AddPlot
 
 type ChildSlots
   = ( canvas :: CanvasSlot Int
@@ -106,7 +106,7 @@ ui =
         ]
       <> inputs
       <> [ HH.button
-            [ HE.onClick $ toActionEvent $ Add ]
+            [ HE.onClick $ toActionEvent $ AddPlot ]
             [ HH.text "Add plot" ]
         , HH.button
             [ HE.onClick $ toActionEvent Clear ]
@@ -180,7 +180,7 @@ handleAction action = do
         newBounds = panBoundsByVector state.input.size state.bounds delta
       drawCommands <- lift $ computePlots state.input.size newBounds state.plots
       H.put state { input { operations = drawCommands }, bounds = newBounds }
-    Add -> do
+    AddPlot -> do
       let
         plots = state.plots <> [ newPlot (1 + length state.plots) ]
       H.put state { plots = plots }

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -8,7 +8,8 @@ import Components.ExpressionInput.Controller (expressionInputController)
 import Constants (canvasId)
 import Control.Monad.Reader (ReaderT, runReaderT)
 import Control.Monad.Trans.Class (lift)
-import Data.Maybe (Maybe(..), isJust)
+import Data.Array (length, mapMaybe, null)
+import Data.Maybe (Maybe(..))
 import Data.Symbol (SProxy(..))
 import Draw.Commands (DrawCommand)
 import Effect (Effect)
@@ -21,7 +22,7 @@ import Halogen.HTML as HH
 import Halogen.HTML.Events as HE
 import Halogen.Query.EventSource as ES
 import Halogen.VDom.Driver (runUI)
-import Plot.Commands (PlotCommand, plot, clear)
+import Plot.Commands (PlotCommand, plotExpression, clear)
 import Plot.Pan (panBounds, panBoundsByVector)
 import Plot.PlotController (computePlotAsync)
 import Plot.Zoom (zoomBounds)
@@ -40,8 +41,13 @@ type Config
 type State
   = { input :: Input (DrawCommand Unit)
     , bounds :: XYBounds
-    , expression :: Maybe Expression
+    , plots :: Array ExpressionPlot
+    }
+
+type ExpressionPlot
+  = { expression :: Maybe Expression
     , expressionText :: String
+    , id :: Int
     }
 
 data Action
@@ -52,6 +58,7 @@ data Action
   | HandleExpressionInput ExpressionInputMessage
   | HandleScroll H.SubscriptionId WheelEvent
   | HandleCanvas CanvasMessage
+  | Add
 
 type ChildSlots
   = ( canvas :: CanvasSlot Int
@@ -86,74 +93,81 @@ ui =
             }
         }
     , bounds: xyBounds (-1.0) (1.0) (-1.0) (1.0)
-    , expressionText: ""
-    , expression: Nothing
+    , plots:
+        [ newPlot 1
+        ]
     }
 
   render :: forall m. MonadEffect m => State -> H.ComponentHTML Action ChildSlots m
   render state =
     HH.div_
-      [ HH.h1_
-          [ HH.text "Robust plot" ]
-      , HH.slot _expressionInput 1 (expressionInputComponent expressionInputController) state.expressionText (Just <<< HandleExpressionInput)
-      , HH.button
-          [ HE.onClick $ toActionEvent Clear ]
-          [ HH.text "Clear plot" ]
-      , HH.button
-          [ HE.onClick $ toActionEvent $ Pan Left ]
-          [ HH.text "◄" ]
-      , HH.button
-          [ HE.onClick $ toActionEvent $ Pan Right ]
-          [ HH.text "►" ]
-      , HH.button
-          [ HE.onClick $ toActionEvent $ Pan Down ]
-          [ HH.text "▼" ]
-      , HH.button
-          [ HE.onClick $ toActionEvent $ Pan Up ]
-          [ HH.text "▲" ]
-      , HH.button
-          [ HE.onClick $ toActionEvent $ Zoom true ]
-          [ HH.text "+" ]
-      , HH.button
-          [ HE.onClick $ toActionEvent $ Zoom false ]
-          [ HH.text "-" ]
-      , HH.slot _canvas 1 (canvasComponent canvasController) state.input (Just <<< HandleCanvas)
-      ]
+      $ [ HH.h1_
+            [ HH.text "Robust plot" ]
+        ]
+      <> inputs
+      <> [ HH.button
+            [ HE.onClick $ toActionEvent $ Add ]
+            [ HH.text "Add plot" ]
+        , HH.button
+            [ HE.onClick $ toActionEvent Clear ]
+            [ HH.text "Clear plots" ]
+        , HH.button
+            [ HE.onClick $ toActionEvent $ Pan Left ]
+            [ HH.text "◄" ]
+        , HH.button
+            [ HE.onClick $ toActionEvent $ Pan Right ]
+            [ HH.text "►" ]
+        , HH.button
+            [ HE.onClick $ toActionEvent $ Pan Down ]
+            [ HH.text "▼" ]
+        , HH.button
+            [ HE.onClick $ toActionEvent $ Pan Up ]
+            [ HH.text "▲" ]
+        , HH.button
+            [ HE.onClick $ toActionEvent $ Zoom true ]
+            [ HH.text "+" ]
+        , HH.button
+            [ HE.onClick $ toActionEvent $ Zoom false ]
+            [ HH.text "-" ]
+        , HH.slot _canvas 1 (canvasComponent canvasController) state.input (Just <<< HandleCanvas)
+        ]
+    where
+    inputs = map (\plot -> HH.slot _expressionInput plot.id (expressionInputComponent expressionInputController plot.id) plot.expressionText (Just <<< HandleExpressionInput)) state.plots
 
 toActionEvent :: forall a. Action -> a -> Maybe Action
 toActionEvent action _ = Just action
-
-computePlot :: Size -> PlotCommand -> ReaderT Config Aff (DrawCommand Unit)
-computePlot canvasSize plot = lift $ computePlotAsync canvasSize plot
 
 handleAction :: forall output. Action -> H.HalogenM State Action ChildSlots output (ReaderT Config Aff) Unit
 handleAction action = do
   state <- H.get
   case action of
     Init -> do
-      drawCommands <- lift $ computePlot state.input.size $ clear state.bounds
       document <- H.liftEffect $ Web.document =<< Web.window
       H.subscribe' \id ->
         ES.eventListenerEventSource
           WET.wheel
           (HTMLDocument.toEventTarget document)
           (map (HandleScroll id) <<< WE.fromEvent)
-      H.put state { input { operations = drawCommands } }
+      handleAction Clear
     Clear -> do
-      drawCommands <- lift $ computePlot state.input.size $ clear state.bounds
-      H.put state { input { operations = drawCommands } }
-    HandleExpressionInput (Parsed expression text) -> do
-      drawCommands <- lift $ computePlot state.input.size $ plot (isJust state.expression) state.bounds expression
-      H.put state { input { operations = drawCommands }, expressionText = text, expression = Just expression }
+      let
+        plots = map (\plot -> plot { expression = Nothing }) state.plots
+      drawCommands <- lift $ computePlots state.input.size state.bounds plots
+      H.put state { input { operations = drawCommands }, plots = plots }
+    HandleExpressionInput (Parsed id expression text) -> do
+      let
+        plots = map (updatePlot id expression text) state.plots
+      drawCommands <- lift $ computePlots state.input.size state.bounds plots
+      H.put state { input { operations = drawCommands }, plots = plots }
     Pan direction -> do
       let
         newBounds = panBounds state.bounds direction
-      drawCommands <- lift $ recomputePlot state newBounds
+      drawCommands <- lift $ computePlots state.input.size newBounds state.plots
       H.put state { input { operations = drawCommands }, bounds = newBounds }
     Zoom isZoomIn -> do
       let
         newBounds = zoomBounds state.bounds isZoomIn
-      drawCommands <- lift $ recomputePlot state newBounds
+      drawCommands <- lift $ computePlots state.input.size newBounds state.plots
       H.put state { input { operations = drawCommands }, bounds = newBounds }
     HandleScroll _ event -> do
       let
@@ -164,16 +178,43 @@ handleAction action = do
     HandleCanvas (Dragged delta) -> do
       let
         newBounds = panBoundsByVector state.input.size state.bounds delta
-      drawCommands <- lift $ recomputePlot state newBounds
+      drawCommands <- lift $ computePlots state.input.size newBounds state.plots
       H.put state { input { operations = drawCommands }, bounds = newBounds }
+    Add -> do
+      let
+        plots = state.plots <> [ newPlot (1 + length state.plots) ]
+      H.put state { plots = plots }
 
 ui' :: forall f i o. H.Component HH.HTML f i o Aff
 ui' = H.hoist (\app -> runReaderT app initialConfig) ui
 
-recomputePlot :: State -> XYBounds -> ReaderT Config Aff (DrawCommand Unit)
-recomputePlot state newBounds = case state.expression of
-  Just expression -> computePlot state.input.size $ plot true newBounds expression
-  Nothing -> computePlot state.input.size $ clear newBounds
+newPlot :: Int -> ExpressionPlot
+newPlot id = { expressionText: "", expression: Nothing, id }
+
+updatePlot :: Int -> Expression -> String -> ExpressionPlot -> ExpressionPlot
+updatePlot id expression text plot = if plot.id == id 
+  then 
+    { expressionText: text, expression: Just expression, id }
+  else 
+    plot
+
+computePlots :: Size -> XYBounds -> Array ExpressionPlot -> ReaderT Config Aff (DrawCommand Unit)
+computePlots canvasSize newBounds plots = lift $ computePlotAsync canvasSize computedPlot
+  where
+  commands = mapMaybe (computePlot canvasSize newBounds) plots
+
+  clearCommand = clear newBounds
+
+  computedPlot =
+    if null commands then
+      [ clearCommand ]
+    else
+      [ clearCommand ] <> commands
+
+computePlot :: Size -> XYBounds -> ExpressionPlot -> Maybe PlotCommand
+computePlot size newBounds plot = case plot.expression of
+  Just expression -> Just $ plotExpression newBounds expression
+  Nothing -> Nothing
 
 initialConfig :: Config
 initialConfig = { someData: "" }

--- a/src/Plot/Commands.purs
+++ b/src/Plot/Commands.purs
@@ -4,11 +4,11 @@ import Expression.Syntax (Expression)
 import Types (XYBounds)
 
 data PlotCommand
-  = Plot Boolean XYBounds Expression
+  = Plot XYBounds Expression
   | Empty XYBounds
 
-plot :: Boolean -> XYBounds -> Expression -> PlotCommand
-plot clearCanvas bounds expression = Plot clearCanvas bounds expression
+plotExpression :: XYBounds -> Expression -> PlotCommand
+plotExpression bounds expression = Plot bounds expression
 
 clear :: XYBounds -> PlotCommand
 clear = Empty

--- a/src/Types.purs
+++ b/src/Types.purs
@@ -15,13 +15,6 @@ type Size
 type Polygon
   = Array Position
 
-type Color
-  = { r :: Number
-    , g :: Number
-    , b :: Number
-    , a :: Number
-    }
-
 data Direction
   = Up
   | Down

--- a/src/Types.purs
+++ b/src/Types.purs
@@ -15,7 +15,7 @@ type Size
 type Polygon
   = Array Position
 
-type RGBA
+type Color
   = { r :: Number
     , g :: Number
     , b :: Number

--- a/src/Types.purs
+++ b/src/Types.purs
@@ -15,4 +15,15 @@ type Size
 type Polygon
   = Array Position
 
-data Direction = Up | Down | Left | Right
+type RGBA
+  = { r :: Number
+    , g :: Number
+    , b :: Number
+    , a :: Number
+    }
+
+data Direction
+  = Up
+  | Down
+  | Left
+  | Right


### PR DESCRIPTION
# Issue(s)
closes #31 
closes #18

# Changes
- Added `Color` type to represent a colour. A colour can be a HexCode string, RGBA record or a named colour like "Red". `NamedColor` was added as a type-safe way to refer to specific colours instead of using strings.
- Formatted `Components.Canvas.Draw`
- `ExpressionPlot` to hold all the plotted data of an expression plot. This resides in the main state whereas each `ExpressionInput` maintains its own temporary state.
- The `Main` component now has a button labelled "Add plot" which will add another `ExpressionInput` slot.
- Formatted `Types` module
- Added bounds input component
- Updated `README.md` to describe how to run the app locally
- Renamed the `server` script in npm with `start` so the developer can just type `npm start`

# Unit test changes
N/A