### PR TITLE
Added plot labels and reset button

### DIFF
--- a/src/Components/Canvas/Draw.purs
+++ b/src/Components/Canvas/Draw.purs
@@ -12,13 +12,11 @@ import Graphics.Canvas (LineCap(..), beginPath, clearRect, fill, fillText, lineT
 import Types (Polygon, Position)
 
 -- | Draws text
-drawText :: String -> Number -> Position -> DrawOperation
-drawText text size { x, y } =
+drawText :: Color -> String -> Number -> Position -> DrawOperation
+drawText color text size { x, y } =
   withLocalDrawContext \drawContext -> do
     let
       font = joinWith " " [ show size <> "px", "Arial" ]
-
-      color = rgba 0.0 0.0 0.0 1.0 
     setFont drawContext.context font
     setFillStyle drawContext.context $ show color
     fillText drawContext.context text x y
@@ -40,7 +38,7 @@ drawLine isDashed color { x: x1, y: y1 } { x: x2, y: y2 } =
     stroke drawContext.context
 
 drawPlotLine :: Position -> Position -> DrawOperation
-drawPlotLine = drawLine false $ rgba 0.0 0.0 0.0 1.0 
+drawPlotLine = drawLine false $ rgba 0.0 0.0 0.0 1.0
 
 drawXAxisLine :: Number -> Number -> DrawOperation
 drawXAxisLine xZero range drawContext = drawPlotLine a b drawContext
@@ -63,20 +61,20 @@ drawYAxisLine yZero range drawContext = drawPlotLine a b drawContext
 drawXGridLine :: Number -> Number -> Number -> DrawOperation
 drawXGridLine x value range drawContext = do
   drawLine true color { x: relativeX, y: 0.0 } { x: relativeX, y: drawContext.canvasHeight } drawContext
-  drawText (show value) 10.0 { x: relativeX, y: drawContext.canvasHeight - 12.0 } drawContext
+  drawText (rgba 0.0 0.0 0.0 1.0) (show value) 10.0 { x: relativeX, y: drawContext.canvasHeight - 12.0 } drawContext
   where
   relativeX = (x * drawContext.canvasWidth) / range
 
-  color = rgba 0.0 0.0 0.0 0.3 
+  color = rgba 0.0 0.0 0.0 0.3
 
 drawYGridLine :: Number -> Number -> Number -> DrawOperation
 drawYGridLine y value range drawContext = do
   drawLine true color { x: 0.0, y: relativeY } { x: drawContext.canvasWidth, y: relativeY } drawContext
-  drawText (show value) 10.0 { x: drawContext.canvasWidth - 40.0, y: relativeY } drawContext
+  drawText (rgba 0.0 0.0 0.0 1.0) (show value) 10.0 { x: drawContext.canvasWidth - 40.0, y: relativeY } drawContext
   where
   relativeY = drawContext.canvasHeight - ((y * drawContext.canvasHeight) / range)
 
-  color = rgba 0.0 0.0 0.0 0.3 
+  color = rgba 0.0 0.0 0.0 0.3
 
 drawPolygon :: Polygon -> DrawOperation
 drawPolygon [] drawContext = pure unit

--- a/src/Components/Canvas/Interpreter.purs
+++ b/src/Components/Canvas/Interpreter.purs
@@ -14,7 +14,7 @@ runDrawCommands drawContext = foldFree interpret
   interpret :: DrawCommandF ~> Effect
   interpret (ClearCanvas n) = const n <$> clearCanvas drawContext
 
-  interpret (DrawText text size pos n) = const n <$> drawText text size pos drawContext
+  interpret (DrawText color text size pos n) = const n <$> drawText color text size pos drawContext
 
   interpret (DrawXGridLine x value range n) = const n <$> drawXGridLine x value range drawContext
 

--- a/src/Draw/Actions.purs
+++ b/src/Draw/Actions.purs
@@ -3,14 +3,15 @@ module Draw.Actions where
 import Prelude
 
 import Control.Monad.Free (liftF)
+import Draw.Color (Color)
 import Draw.Commands (DrawCommand, DrawCommandF(..))
 import Types (Position, Polygon)
 
 clearCanvas :: DrawCommand Unit
 clearCanvas = liftF $ ClearCanvas unit
 
-drawText :: String -> Number -> Position -> DrawCommand Unit
-drawText text height pos = liftF $ DrawText text height pos unit
+drawText :: Color -> String -> Number -> Position -> DrawCommand Unit
+drawText color text height pos = liftF $ DrawText color text height pos unit
 
 drawXGridLine :: Number -> Number -> Number -> DrawCommand Unit
 drawXGridLine x value range = liftF $ DrawXGridLine x value range unit

--- a/src/Draw/Commands.purs
+++ b/src/Draw/Commands.purs
@@ -1,6 +1,7 @@
 module Draw.Commands where
 
 import Control.Monad.Free (Free)
+import Draw.Color (Color)
 import Types (Position, Polygon)
 
 type DrawCommand
@@ -8,7 +9,7 @@ type DrawCommand
 
 data DrawCommandF n
   = ClearCanvas n
-  | DrawText String Number Position n
+  | DrawText Color String Number Position n
   | DrawXGridLine Number Number Number n
   | DrawYGridLine Number Number Number n
   | DrawPolygon Polygon n

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -181,7 +181,7 @@ handleAction action = do
       H.put state { input { operations = drawCommands }, bounds = newBounds }
     ResetBounds -> do
       drawCommands <- lift $ computePlots state.input.size initialBounds state.plots
-      H.put state { input { operations = drawCommands }, bounds = newBounds }
+      H.put state { input { operations = drawCommands }, bounds = initialBounds }
     HandleScroll _ event -> do
       let
         changeInY = WE.deltaY event

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -61,6 +61,7 @@ data Action
   | HandleCanvas CanvasMessage
   | HandleBoundsInput BoundsInputMessage
   | AddPlot
+  | ResetBounds
 
 type ChildSlots
   = ( canvas :: CanvasSlot Int
@@ -97,7 +98,7 @@ ui =
             , height: 500.0
             }
         }
-    , bounds: xyBounds (-1.0) (1.0) (-1.0) (1.0)
+    , bounds: initialBounds
     , plots:
         [ newPlot 1
         ]
@@ -117,6 +118,9 @@ ui =
             [ HE.onClick $ toActionEvent Clear ]
             [ HH.text "Clear plots" ]
         , HH.slot _boundsInput 1 boundsInputComponent state.bounds (Just <<< HandleBoundsInput)
+        , HH.button
+            [ HE.onClick $ toActionEvent $ ResetBounds ]
+            [ HH.text "Reset" ]
         , HH.button
             [ HE.onClick $ toActionEvent $ Pan Left ]
             [ HH.text "◄" ]
@@ -175,6 +179,9 @@ handleAction action = do
         newBounds = zoomBounds state.bounds isZoomIn
       drawCommands <- lift $ computePlots state.input.size newBounds state.plots
       H.put state { input { operations = drawCommands }, bounds = newBounds }
+    ResetBounds -> do
+      drawCommands <- lift $ computePlots state.input.size initialBounds state.plots
+      H.put state { input { operations = drawCommands }, bounds = newBounds }
     HandleScroll _ event -> do
       let
         changeInY = WE.deltaY event
@@ -206,6 +213,9 @@ updatePlot id expression text plot =
     { expressionText: text, expression: Just expression, id }
   else
     plot
+
+initialBounds :: XYBounds
+initialBounds = xyBounds (-1.0) (1.0) (-1.0) (1.0)
 
 computePlots :: Size -> XYBounds -> Array ExpressionPlot -> ReaderT Config Aff (DrawCommand Unit)
 computePlots canvasSize newBounds plots = lift $ computePlotAsync canvasSize computedPlot

--- a/src/Plot/Commands.purs
+++ b/src/Plot/Commands.purs
@@ -12,3 +12,7 @@ plotExpression bounds expression = Plot bounds expression
 
 clear :: XYBounds -> PlotCommand
 clear = Empty
+
+isPlotExpression :: PlotCommand -> Boolean
+isPlotExpression (Plot _ _) = true
+isPlotExpression (Empty _) = false

--- a/src/Plot/PlotController.purs
+++ b/src/Plot/PlotController.purs
@@ -60,7 +60,7 @@ runCommand canvasSize numberOfPlots index (Plot bounds expression) = drawCommand
   drawCommands = fold [ drawPlot points, label expression points numberOfPlots index ]
 
 isWithinCanvas :: Size -> Position -> Boolean
-isWithinCanvas canvasSize point = point.x >= 0.0 && point.x < canvasSize.width && point.y >= 0.0 && point.y < canvasSize.height
+isWithinCanvas canvasSize point = point.x >= 0.0 && point.x <= canvasSize.width + 1.0 && point.y >= 0.0 && point.y <= canvasSize.height + 1.0
 
 label :: Expression -> Array Position -> Int -> Int -> DrawCommand Unit
 label expression points numberOfPlots index = drawText color ("f(x)=" <> (show expression)) 20.0 labelPosition

--- a/src/Plot/PlotController.purs
+++ b/src/Plot/PlotController.purs
@@ -1,6 +1,7 @@
 module Plot.PlotController where
 
 import Prelude
+
 import Data.Array (concat, fold, length, tail, zipWith, (!!), (..), mapWithIndex, filter)
 import Data.Either (Either(..))
 import Data.Int (floor, toNumber)
@@ -8,6 +9,7 @@ import Data.Maybe (Maybe(..), fromMaybe)
 import Data.Traversable (for_, sum)
 import Data.Tuple (Tuple(..))
 import Draw.Actions (drawPlotLine, drawText)
+import Draw.Color (rgba)
 import Draw.Commands (DrawCommand)
 import Effect (Effect)
 import Effect.Aff (Aff, Canceler, Error, makeAff, nonCanceler)
@@ -61,9 +63,11 @@ isWithinCanvas :: Size -> Position -> Boolean
 isWithinCanvas canvasSize point = point.x >= 0.0 && point.x < canvasSize.width && point.y >= 0.0 && point.y < canvasSize.height
 
 label :: Expression -> Array Position -> Int -> Int -> DrawCommand Unit
-label expression points numberOfPlots index = drawText ("f(x)=" <> (show expression)) 20.0 labelPosition
+label expression points numberOfPlots index = drawText color ("f(x)=" <> (show expression)) 20.0 labelPosition
   where
   pointIndex = (length points) / (numberOfPlots + 1)
+
+  color = rgba 255.0 0.0 0.0 1.0
 
   labelPosition = fromMaybe { x: 0.0, y: 0.0 } $ points !! (pointIndex * index)
 


### PR DESCRIPTION
# Issue(s)
closes #42 
closes #32 

# Changes
- Added `Color` as a parameter to `drawText` for drawing text so the text colour can be changed
- Added `Reset` button that will reset the bounds of the plot to its initial value
- Altered plotting so that points that are not visible on the canvas are not turned into `DrawCommand`s

# Unit test changes
N/A