### PR TITLE
Approx field arithmetic, conversions

### DIFF
--- a/src/IntervalArith/Approx/Approx.purs
+++ b/src/IntervalArith/Approx/Approx.purs
@@ -241,7 +241,7 @@ approximatedBy r d =
 better :: Approx -> Approx -> Boolean
 better d e = (lowerBound e <= lowerBound d) && (upperBound d <= upperBound e)
 
-infix 4 better as ⊑ 
+infix 4 better as ⊑
 
 -- |Turns a 'Dyadic' number into an exact approximation.
 fromDyadic :: Dyadic -> Approx

--- a/src/IntervalArith/Approx/Approx.purs
+++ b/src/IntervalArith/Approx/Approx.purs
@@ -5,6 +5,7 @@
 module IntervalArith.Approx where
 
 import Prelude
+
 import Control.Biapply (biapply)
 import Data.BigInt (abs)
 import Data.Foldable (intercalate)
@@ -14,7 +15,7 @@ import Data.Tuple (Tuple(..))
 import Data.Typelevel.Undefined (undefined)
 import Effect.Exception.Unsafe (unsafeThrow)
 import FFI.BigInt (bitLength)
-import IntervalArith.Dyadic (Dyadic, (:^))
+import IntervalArith.Dyadic (Dyadic, dyadicToNumber, (:^))
 import IntervalArith.Dyadic as Dyadic
 import IntervalArith.Extended (Extended(..))
 import IntervalArith.Misc (Rational, class ToRational, Integer, big, scale, shift, toRational)
@@ -193,6 +194,13 @@ boundsR :: Approx -> Tuple (Extended Rational) (Extended Rational)
 boundsR a = biapply (Tuple f f) (bounds a)
   where
   f = map toRational
+
+boundsNumber :: Approx -> Tuple Number Number
+boundsNumber a = biapply (Tuple f f) (bounds a)
+  where
+  f PosInf = 1.0/0.0
+  f NegInf = -1.0/0.0
+  f (Finite d) = dyadicToNumber d
 
 -- |Gives the lower bound of an 'Approx' as an exact 'Approx'.
 lowerA :: Approx -> Approx

--- a/src/IntervalArith/Approx/Approx.purs
+++ b/src/IntervalArith/Approx/Approx.purs
@@ -241,7 +241,12 @@ approximatedBy r d =
 better :: Approx -> Approx -> Boolean
 better d e = (lowerBound e <= lowerBound d) && (upperBound d <= upperBound e)
 
-infix 4 better as ⊑
+worse :: Approx -> Approx -> Boolean
+worse = flip better
+
+infix 4 worse as ⊑
+
+infix 4 better as ⊒
 
 -- |Turns a 'Dyadic' number into an exact approximation.
 fromDyadic :: Dyadic -> Approx

--- a/src/IntervalArith/Approx/Approx.purs
+++ b/src/IntervalArith/Approx/Approx.purs
@@ -5,10 +5,12 @@
 module IntervalArith.Approx where
 
 import Prelude
+import Control.Biapply (biapply)
 import Data.BigInt (abs)
 import Data.Foldable (intercalate)
 import Data.Maybe (Maybe(..))
 import Data.Ratio (denominator, numerator)
+import Data.Tuple (Tuple(..))
 import Data.Typelevel.Undefined (undefined)
 import Effect.Exception.Unsafe (unsafeThrow)
 import FFI.BigInt (bitLength)
@@ -181,6 +183,16 @@ upperBound :: Approx -> Extended Dyadic
 upperBound (Approx _ m e s) = Finite ((m + e) :^ s)
 
 upperBound Bottom = PosInf
+
+bounds :: Approx -> Tuple (Extended Dyadic) (Extended Dyadic)
+bounds (Approx _ m e s) = Tuple (Finite ((m - e) :^ s)) (Finite ((m + e) :^ s))
+
+bounds Bottom = Tuple NegInf PosInf
+
+boundsR :: Approx -> Tuple (Extended Rational) (Extended Rational)
+boundsR a = biapply (Tuple f f) (bounds a)
+  where
+  f = map toRational
 
 -- |Gives the lower bound of an 'Approx' as an exact 'Approx'.
 lowerA :: Approx -> Approx

--- a/src/IntervalArith/Approx/Approx.purs
+++ b/src/IntervalArith/Approx/Approx.purs
@@ -264,6 +264,13 @@ better d e = (lowerBound e <= lowerBound d) && (upperBound d <= upperBound e)
 worse :: Approx -> Approx -> Boolean
 worse = flip better
 
+consistent :: Approx -> Approx -> Boolean
+consistent Bottom _ = true
+consistent _ Bottom = true
+consistent d e = 
+  not $ (upperBound e < lowerBound d) || (upperBound d < lowerBound e)
+
+
 infix 4 worse as ⊑
 
 infix 4 better as ⊒

--- a/src/IntervalArith/Approx/Approx.purs
+++ b/src/IntervalArith/Approx/Approx.purs
@@ -84,7 +84,10 @@ data Approx
   = Approx Int Integer Integer Int
   | Bottom
 
-instance approxShow :: Show Approx where
+-- | Syntactic equality
+derive instance eqApprox :: Eq Approx
+
+instance showApprox :: Show Approx where
   show (Approx b m e s) = intercalate " " [ "Approx", show b, "(", show m, ") (", show e, ")", show s ]
   show Bottom = "Bottom"
 
@@ -237,6 +240,8 @@ approximatedBy r d =
 -- the second if it is a sub-interval of the second.
 better :: Approx -> Approx -> Boolean
 better d e = (lowerBound e <= lowerBound d) && (upperBound d <= upperBound e)
+
+infix 4 better as ⊑ 
 
 -- |Turns a 'Dyadic' number into an exact approximation.
 fromDyadic :: Dyadic -> Approx

--- a/src/IntervalArith/Approx/Approx.purs
+++ b/src/IntervalArith/Approx/Approx.purs
@@ -7,9 +7,13 @@ module IntervalArith.Approx where
 import Prelude
 import Data.BigInt (abs)
 import Data.Foldable (intercalate)
+import Data.Maybe (Maybe(..))
 import Effect.Exception.Unsafe (unsafeThrow)
 import FFI.BigInt (bitLength)
-import IntervalArith.Misc (Integer, big, shift)
+import IntervalArith.Dyadic (Dyadic, (:^))
+import IntervalArith.Dyadic as Dyadic
+import IntervalArith.Extended (Extended(..))
+import IntervalArith.Misc (class ToRational, Integer, big, scale, shift, toRational)
 
 -- | A type synonym. Used to denote number of bits after binary point.
 type Precision
@@ -140,27 +144,39 @@ mapMB _f Bottom = Bottom
 setMB :: Int -> Approx -> Approx
 setMB mb = mapMB (const mb)
 
--- -- |Construct a centred approximation from the end-points.
--- endToApprox :: Int -> Extended Dyadic -> Extended Dyadic -> Approx
--- endToApprox mb (Finite l) (Finite u)
---   | u < l = Bottom -- Might be better with a signalling error.
---   | otherwise =
---     let a@(m:^s) = scale (l + u) (-1)
---         (n:^t)   = u-a
---         r        = min s t
---         m'       = unsafeShiftL m (s-r)
---         n'       = unsafeShiftL n (t-r)
---     in (approxMB mb m' n' r)
--- endToApprox _ _ _ = Bottom
--- -- Interval operations
--- -- |Gives the lower bound of an approximation as an 'Extended' 'Dyadic' number.
--- lowerBound :: Approx -> Extended Dyadic
--- lowerBound (Approx _ m e s) = Finite ((m-e):^s)
--- lowerBound Bottom = NegInf
--- -- |Gives the upper bound of an approximation as an 'Extended' 'Dyadic' number.
--- upperBound :: Approx -> Extended Dyadic
--- upperBound (Approx _ m e s) = Finite ((m+e):^s)
--- upperBound Bottom = PosInf
+-- |Construct a centred approximation from the end-points.
+endToApprox :: Int -> Extended Dyadic -> Extended Dyadic -> Approx
+endToApprox mb (Finite l) (Finite u)
+  | u < l = Bottom -- Might be better with a signalling error.
+  | otherwise =
+    let
+      a@(m :^ s) = scale (l + u) (-1)
+
+      (n :^ t) = u - a
+
+      r = min s t
+
+      m' = scale m (s - r)
+
+      n' = scale n (t - r)
+    in
+      (approxMB mb m' n' r)
+
+endToApprox _ _ _ = Bottom
+
+-- Interval operations
+-- |Gives the lower bound of an approximation as an 'Extended' 'Dyadic' number.
+lowerBound :: Approx -> Extended Dyadic
+lowerBound (Approx _ m e s) = Finite ((m - e) :^ s)
+
+lowerBound Bottom = NegInf
+
+-- |Gives the upper bound of an approximation as an 'Extended' 'Dyadic' number.
+upperBound :: Approx -> Extended Dyadic
+upperBound (Approx _ m e s) = Finite ((m + e) :^ s)
+
+upperBound Bottom = PosInf
+
 -- |Gives the lower bound of an 'Approx' as an exact 'Approx'.
 lowerA :: Approx -> Approx
 lowerA Bottom = Bottom
@@ -173,46 +189,57 @@ upperA Bottom = Bottom
 
 upperA (Approx mb m e s) = Approx mb (m + e) (big 0) s
 
--- -- |Gives the mid-point of an approximation as a 'Maybe' 'Dyadic' number.
--- centre :: Approx -> Maybe Dyadic
--- centre (Approx _ m _ s) = Just (m:^s)
--- centre _ = Nothing
+-- |Gives the mid-point of an approximation as a 'Maybe' 'Dyadic' number.
+centre :: Approx -> Maybe Dyadic
+centre (Approx _ m _ s) = Just (m :^ s)
+
+centre _ = Nothing
+
 -- |Gives the centre of an 'Approx' as an exact 'Approx'.
 centreA :: Approx -> Approx
 centreA Bottom = Bottom
 
 centreA (Approx mb m _e s) = Approx mb m (big 0) s
 
--- -- |Gives the radius of an approximation as a 'Dyadic' number. Currently a
--- -- partial function. Should be made to return an 'Extended' 'Dyadic'.
--- radius :: Approx -> Extended Dyadic
--- radius (Approx _ _ e s) = Finite (e:^s)
--- radius _ = PosInf
--- -- |Gives the lower bound of an approximation as an 'Extended' 'Dyadic' number.
--- diameter :: Approx -> Extended Dyadic
--- diameter (Approx _ _ e s) = Finite $ 2 * (e:^s)
--- diameter _ = PosInf
+-- |Gives the radius of an approximation as a 'Dyadic' number. Currently a
+-- partial function. Should be made to return an 'Extended' 'Dyadic'.
+radius :: Approx -> Extended Dyadic
+radius (Approx _ _ e s) = Finite (e :^ s)
+
+radius _ = PosInf
+
+-- |Gives the lower bound of an approximation as an 'Extended' 'Dyadic' number.
+diameter :: Approx -> Extended Dyadic
+diameter (Approx _ _ e s) = Finite $ (Dyadic.fromInt 2) * (e :^ s)
+
+diameter _ = PosInf
+
 -- |Returns 'True' if the approximation is exact, i.e., it's diameter is 0.
 exact :: Approx -> Boolean
 exact (Approx _ _ e _) = e == (big 0)
 
 exact Bottom = false
 
--- -- |Checks if a number is approximated by an approximation, i.e., if it
--- -- belongs to the interval encoded by the approximation.
--- -- approximatedBy :: Real a => a -> Approx -> Bool
--- _ `approximatedBy` Bottom = True
--- r `approximatedBy` d =
---     let r' = toRational r
---     in toRational (lowerBound d) <= r' && r' <= toRational (upperBound d)
--- -- |A partial order on approximations. The first approximation is better than
--- -- the second if it is a sub-interval of the second.
--- better :: Approx -> Approx -> Bool
--- d `better` e = lowerBound d >= lowerBound e &&
---                upperBound d <= upperBound e
--- -- |Turns a 'Dyadic' number into an exact approximation.
--- fromDyadic :: Dyadic -> Approx
--- fromDyadic (m:^s) = approxAutoMB m 0 s
--- -- |Turns a 'Dyadic' number into an exact approximation.
--- fromDyadicMB :: Int -> Dyadic -> Approx
--- fromDyadicMB mb (m:^s) = approxMB mb m 0 s
+-- |Checks if a number is approximated by an approximation, i.e., if it
+-- belongs to the interval encoded by the approximation.
+approximatedBy :: forall a. ToRational a => a -> Approx -> Boolean
+approximatedBy _ Bottom = true
+
+approximatedBy r d =
+  let
+    r' = toRational r
+  in
+    toRational (lowerBound d) <= r' && r' <= toRational (upperBound d)
+
+-- |A partial order on approximations. The first approximation is better than
+-- the second if it is a sub-interval of the second.
+better :: Approx -> Approx -> Boolean
+better d e = (lowerBound e <= lowerBound d) && (upperBound d <= upperBound e)
+
+-- |Turns a 'Dyadic' number into an exact approximation.
+fromDyadic :: Dyadic -> Approx
+fromDyadic (m :^ s) = approxAutoMB m (big 0) s
+
+-- |Turns a 'Dyadic' number into an exact approximation.
+fromDyadicMB :: Int -> Dyadic -> Approx
+fromDyadicMB mb (m :^ s) = approxMB mb m (big 0) s

--- a/src/IntervalArith/Dyadic.purs
+++ b/src/IntervalArith/Dyadic.purs
@@ -1,6 +1,8 @@
 module IntervalArith.Dyadic where
 
 import Prelude
+
+import Data.BigInt as BigInt
 import IntervalArith.Misc ((^^), class Scalable, class ToRational, Integer, big, scale, shift, toRational)
 
 -- |The Dyadic data type.
@@ -48,3 +50,6 @@ fromInt i = (big i) :^ 0
 
 instance toRationalDyadic :: ToRational Dyadic where
   toRational (a :^ s) = (toRational a) * (toRational 2) ^^ s
+
+dyadicToNumber :: Dyadic -> Number
+dyadicToNumber (a :^ s) = (BigInt.toNumber a) * (2.0) ^^ s

--- a/src/IntervalArith/Dyadic.purs
+++ b/src/IntervalArith/Dyadic.purs
@@ -43,5 +43,8 @@ instance commutativeRingDyadic :: CommutativeRing Dyadic
 fromInteger :: Integer -> Dyadic
 fromInteger i = i :^ 0
 
+fromInt :: Int -> Dyadic
+fromInt i = (big i) :^ 0
+
 instance toRationalDyadic :: ToRational Dyadic where
   toRational (a :^ s) = (toRational a) * (toRational 2) ^^ s

--- a/src/IntervalArith/Misc.purs
+++ b/src/IntervalArith/Misc.purs
@@ -1,7 +1,6 @@
 module IntervalArith.Misc where
 
 import Prelude
-
 import Data.BigInt (BigInt)
 import Data.BigInt as BigInt
 import Data.Int as Int
@@ -40,6 +39,11 @@ shift x n = BigInt.shl x (Int.toNumber n)
 bit :: Int -> Integer
 bit n = shift (big 1) n
 
+-- | testBit b n is true iff the n'th bit of of b is 1.
+testBit :: Integer -> Int -> Boolean
+testBit b n = (BigInt.and b (bit n)) /= zero
+
+
 {-- Rational --}
 type Rational
   = Ratio BigInt
@@ -54,8 +58,20 @@ instance toRationalInteger :: ToRational BigInt where
   toRational n = n % (big 1)
 
 rationalToNumber :: Rational -> Number
-rationalToNumber q = 
-  (BigInt.toNumber (numerator q)) / (BigInt.toNumber (denominator q))
+rationalToNumber q = (BigInt.toNumber (numerator q)) / (BigInt.toNumber (denominator q))
+
+roundRational :: Rational -> Integer
+roundRational r =
+  let
+    p = numerator r
+
+    q = denominator r
+
+    p2 = shift p 1
+
+    q2 = shift q 1
+  in
+    (p2 + q) `div` q2
 
 {-- Scalable --}
 -- | 'Scalable' allows scaling numerical data types by powers of 2.

--- a/src/IntervalArith/Misc.purs
+++ b/src/IntervalArith/Misc.purs
@@ -1,7 +1,9 @@
 module IntervalArith.Misc where
 
 import Prelude
-import Data.BigInt (BigInt, fromInt, shl)
+
+import Data.BigInt (BigInt)
+import Data.BigInt as BigInt
 import Data.Int as Int
 import Data.Monoid (power)
 import Data.Monoid.Multiplicative (Multiplicative(..))
@@ -30,10 +32,10 @@ type Integer
   = BigInt
 
 big :: Int -> Integer
-big = fromInt
+big = BigInt.fromInt
 
 shift :: Integer -> Int -> Integer
-shift x n = shl x (Int.toNumber n)
+shift x n = BigInt.shl x (Int.toNumber n)
 
 bit :: Int -> Integer
 bit n = shift (big 1) n
@@ -50,6 +52,10 @@ instance toRationalInt :: ToRational Int where
 
 instance toRationalInteger :: ToRational BigInt where
   toRational n = n % (big 1)
+
+rationalToNumber :: Rational -> Number
+rationalToNumber q = 
+  (BigInt.toNumber (numerator q)) / (BigInt.toNumber (denominator q))
 
 {-- Scalable --}
 -- | 'Scalable' allows scaling numerical data types by powers of 2.

--- a/src/IntervalArith/Misc.purs
+++ b/src/IntervalArith/Misc.purs
@@ -1,7 +1,7 @@
 module IntervalArith.Misc where
 
 import Prelude
-import Data.BigInt (BigInt, fromInt, shl)
+import Data.BigInt (BigInt)
 import Data.BigInt as BigInt
 import Data.Int as Int
 import Data.Monoid (power)

--- a/src/IntervalArith/Misc.purs
+++ b/src/IntervalArith/Misc.purs
@@ -39,6 +39,11 @@ shift x n = BigInt.shl x (Int.toNumber n)
 bit :: Int -> Integer
 bit n = shift (big 1) n
 
+-- | testBit b n is true iff the n'th bit of of b is 1.
+testBit :: Integer -> Int -> Boolean
+testBit b n = (BigInt.and b (bit n)) /= zero
+
+
 {-- Rational --}
 type Rational
   = Ratio BigInt
@@ -53,8 +58,20 @@ instance toRationalInteger :: ToRational BigInt where
   toRational n = n % (big 1)
 
 rationalToNumber :: Rational -> Number
-rationalToNumber q = 
-  (BigInt.toNumber (numerator q)) / (BigInt.toNumber (denominator q))
+rationalToNumber q = (BigInt.toNumber (numerator q)) / (BigInt.toNumber (denominator q))
+
+roundRational :: Rational -> Integer
+roundRational r =
+  let
+    p = numerator r
+
+    q = denominator r
+
+    p2 = shift p 1
+
+    q2 = shift q 1
+  in
+    (p2 + q) `div` q2
 
 {-- Scalable --}
 -- | 'Scalable' allows scaling numerical data types by powers of 2.

--- a/src/IntervalArith/Misc.purs
+++ b/src/IntervalArith/Misc.purs
@@ -31,10 +31,10 @@ type Integer
   = BigInt
 
 big :: Int -> Integer
-big = fromInt
+big = BigInt.fromInt
 
 shift :: Integer -> Int -> Integer
-shift x n = shl x (Int.toNumber n)
+shift x n = BigInt.shl x (Int.toNumber n)
 
 bit :: Int -> Integer
 bit n = shift (big 1) n
@@ -51,6 +51,10 @@ instance toRationalInt :: ToRational Int where
 
 instance toRationalInteger :: ToRational BigInt where
   toRational n = n % (big 1)
+
+rationalToNumber :: Rational -> Number
+rationalToNumber q = 
+  (BigInt.toNumber (numerator q)) / (BigInt.toNumber (denominator q))
 
 {-- Scalable --}
 -- | 'Scalable' allows scaling numerical data types by powers of 2.
@@ -74,7 +78,3 @@ instance scalableRational :: Scalable (Ratio BigInt) where
     result
       | n >= 0 = shift a n % b
       | otherwise = a % shift b (-n)
-
-rationalToNumber :: Rational -> Number
-rationalToNumber q = 
- (BigInt.toNumber (numerator q)) / (BigInt.toNumber (denominator q))

--- a/test/Field.purs
+++ b/test/Field.purs
@@ -1,0 +1,51 @@
+module Test.Field where
+
+import Prelude
+
+import IntervalArith.Approx (consistent)
+import Test.QuickCheck (class Arbitrary)
+import Test.QuickCheck.Combinators ((&=&), (|=|))
+import Test.Ring (commutativeRingTests)
+import Test.TestUtils (SuiteEqParams1)
+import Test.Unit (TestSuite, suite, test)
+import Test.Unit.Assert (assert)
+import Test.Unit.QuickCheck (quickCheck)
+
+fieldTests ::
+  forall at t. Arbitrary at => Field t => SuiteEqParams1 at t -> TestSuite
+fieldTests params =
+  suite (params.suitePrefix <> " forms a field") do
+    commutativeRingTests params
+    divisionRingLaws params
+
+divisionRingLaws ::
+  forall at t. Arbitrary at => DivisionRing t => SuiteEqParams1 at t -> TestSuite
+divisionRingLaws p =
+  suite (p.suitePrefix <> " satisfies division ring laws") do
+    test
+      ( "SHOULD HOLD multiplicative inverse: recip a * a "
+          <> p.eqOpSymbol
+          <> " a * recip a "
+          <> p.eqOpSymbol
+          <> " one "
+          <> "FOR ALL "
+          <> p.valuesName
+          <> " a "
+          <> "!" <> p.eqOpSymbol
+          <> " zero"
+      )
+      $ quickCheck \aA ->
+          let
+            a = p.fromArbitraryValue aA
+
+            eqOp = p.eqOpWithInput [ a ]
+          in
+            (a `eqOp` zero) |=| 
+            (((recip a * a) `eqOp` one)
+              &=& ((a * recip a) `eqOp` one))
+    test
+      ( "SHOULD HOLD non-zero ring: " <>
+          "zero " <> "!" <> p.eqOpSymbol <> " one"
+      ) 
+      $ assert "Could not separate 0 from 1"
+        $ not $ consistent zero one

--- a/test/IntervalArith/Approx/Approx.purs
+++ b/test/IntervalArith/Approx/Approx.purs
@@ -3,9 +3,8 @@ module Test.IntervalArith.Approx
   ) where
 
 import Prelude
-
 import Effect (Effect)
-import IntervalArith.Approx (Approx(..), approxMB, better, setMB, (⊑))
+import IntervalArith.Approx (Approx(..), approxMB, setMB, (⊑))
 import IntervalArith.Approx.ShowA (showA)
 import IntervalArith.Misc (big)
 import Test.IntervalArith.Approx.ShowA (approxTests_showA)
@@ -41,7 +40,7 @@ approxTests = do
 approxTests_setMBworse :: TestSuite
 approxTests_setMBworse =
   suite "IntervalArith.Approx - setMB" do
-    test "SHOULD HOLD setMB mb a ⊒ a FOR ALL approx a and integer mb>=0"
+    test "SHOULD HOLD setMB mb a ⊑ a FOR ALL approx a and integer mb>=0"
       $ quickCheck \aPre mbPre ->
           let
             -- given
@@ -53,10 +52,10 @@ approxTests_setMBworse =
             aMB = setMB mb a
           -- then
           in
-            assertOp (flip better) " ⊒ " aMB a
+            assertOp (⊑) " ⊑ " aMB a
 
 approxTests_Order :: TestSuite
-approxTests_Order = 
+approxTests_Order =
   suite "IntervalArith.Approx - approximation order (`better`)" do
     test "SHOULD give (Approx 4 12 1 3 = 96±8 \"1~~\") WHEN setMB 4 (Approx 10 100 0 0 ~ \"100\")" do
       let
@@ -80,4 +79,8 @@ approxOrdParams =
   , leqOpSymbol: "⊑"
   , eqOpWithInput: (assertOpWithInput (==) " == ")
   , eqOpSymbol: "="
+  , makeLeq:
+      \a b -> case b of
+        (Approx mb _ _ _) -> setMB mb a
+        Bottom -> Bottom
   }

--- a/test/IntervalArith/Approx/Approx.purs
+++ b/test/IntervalArith/Approx/Approx.purs
@@ -2,9 +2,44 @@ module Test.IntervalArith.Approx
   ( approxTests
   ) where
 
+import Prelude
+
+import IntervalArith.Approx (Approx(..), approxMB, (⊑))
+import IntervalArith.Misc (big)
+import Test.IntervalArith.Approx.ShowA (approxTests_showA)
+import Test.IntervalArith.Misc (ArbitraryInteger(..))
+import Test.Order (partialOrderTests, preOrderTests)
+import Test.QuickCheck (class Arbitrary, arbitrary)
+import Test.QuickCheck.Gen (chooseInt, sized)
+import Test.TestUtils (SuiteOrdParams1, assertOpWithInput)
 import Test.Unit (TestSuite)
-import Test.IntervalArith.Approx.ShowA (showATests)
+
+data ArbitraryApprox = ArbitraryApprox Approx
+
+instance arbitraryApprox :: Arbitrary ArbitraryApprox where
+  arbitrary =
+    sized \size -> do
+      (ArbitraryInteger m) <- arbitrary
+      s <- chooseInt (-2 * size) (2 * size)
+      mb <- chooseInt 2 (10 + 2 * size)
+      pure $ ArbitraryApprox $ approxMB mb m (big 0) s
 
 approxTests :: TestSuite
 approxTests = do
-  showATests
+  approxTests_showA
+  approxTests_Order
+
+approxTests_Order :: TestSuite
+approxTests_Order = preOrderTests approxOrdParams
+  
+
+approxOrdParams :: SuiteOrdParams1 ArbitraryApprox Approx
+approxOrdParams =
+  { suitePrefix: "IntervalArith.Approx ⊑"
+  , valuesName: "interval approximations"
+  , fromArbitraryValue: \(ArbitraryApprox d) -> d
+  , leqOpWithInput: (assertOpWithInput (⊑) " ⊑ ")
+  , leqOpSymbol: "⊑"
+  , eqOpWithInput: (assertOpWithInput (==) " == ")
+  , eqOpSymbol: "="
+  }

--- a/test/IntervalArith/Approx/Approx.purs
+++ b/test/IntervalArith/Approx/Approx.purs
@@ -3,6 +3,7 @@ module Test.IntervalArith.Approx
   ) where
 
 import Prelude
+
 import Effect (Effect)
 import IntervalArith.Approx (Approx(..), approxMB, consistent, setMB, (⊑))
 import IntervalArith.Approx.ShowA (showA)
@@ -12,7 +13,8 @@ import Test.IntervalArith.Misc (ArbitraryInteger(..), ArbitraryPositiveExponent(
 import Test.Order (preOrderTests)
 import Test.QuickCheck (class Arbitrary, arbitrary)
 import Test.QuickCheck.Gen (Size, chooseInt, randomSample', sized)
-import Test.TestUtils (SuiteOrdParams1, assertOp, assertOpWithInput)
+import Test.Ring (commutativeRingTests)
+import Test.TestUtils (SuiteOrdParams1, SuiteEqParams1, assertOp, assertOpWithInput)
 import Test.Unit (TestSuite, suite, test)
 import Test.Unit.Assert (equal)
 import Test.Unit.QuickCheck (quickCheck)
@@ -37,6 +39,7 @@ approxTests = do
   approxTests_setMBworse
   approxTests_Order
   approxTests_Consistent
+  approxTests_Ring
 
 approxTests_setMBworse :: TestSuite
 approxTests_setMBworse =
@@ -99,6 +102,9 @@ approxTests_Consistent =
           in
             assertOp consistent " `consistent` " a b
 
+approxTests_Ring :: TestSuite
+approxTests_Ring = commutativeRingTests approxEqParams
+
 approxOrdParams :: SuiteOrdParams1 ArbitraryApprox Approx
 approxOrdParams =
   { suitePrefix: "IntervalArith.Approx ⊑"
@@ -112,4 +118,13 @@ approxOrdParams =
       \a b -> case b of
         (Approx mb _ _ _) -> setMB mb a
         Bottom -> Bottom
+  }
+
+approxEqParams :: SuiteEqParams1 ArbitraryApprox Approx
+approxEqParams =
+  { suitePrefix: "IntervalArith.Approx - "
+  , valuesName: "interval approximations"
+  , fromArbitraryValue: \(ArbitraryApprox d) -> d
+  , eqOpWithInput: (assertOpWithInput consistent " ~ ")
+  , eqOpSymbol: "~"
   }

--- a/test/IntervalArith/Approx/Approx.purs
+++ b/test/IntervalArith/Approx/Approx.purs
@@ -2,9 +2,43 @@ module Test.IntervalArith.Approx
   ( approxTests
   ) where
 
+import Prelude
+import IntervalArith.Approx (Approx, approxMB, (⊑))
+import IntervalArith.Misc (big)
+import Test.IntervalArith.Approx.ShowA (approxTests_showA)
+import Test.IntervalArith.Misc (ArbitraryInteger(..))
+import Test.Order (preOrderTests)
+import Test.QuickCheck (class Arbitrary, arbitrary)
+import Test.QuickCheck.Gen (chooseInt, sized)
+import Test.TestUtils (SuiteOrdParams1, assertOpWithInput)
 import Test.Unit (TestSuite)
-import Test.IntervalArith.Approx.ShowA (showATests)
+
+data ArbitraryApprox
+  = ArbitraryApprox Approx
+
+instance arbitraryApprox :: Arbitrary ArbitraryApprox where
+  arbitrary =
+    sized \size -> do
+      (ArbitraryInteger m) <- arbitrary
+      s <- chooseInt (-2 * size) (2 * size)
+      mb <- chooseInt 2 (10 + 2 * size)
+      pure $ ArbitraryApprox $ approxMB mb m (big 0) s
 
 approxTests :: TestSuite
 approxTests = do
-  showATests
+  approxTests_showA
+  approxTests_Order
+
+approxTests_Order :: TestSuite
+approxTests_Order = preOrderTests approxOrdParams
+
+approxOrdParams :: SuiteOrdParams1 ArbitraryApprox Approx
+approxOrdParams =
+  { suitePrefix: "IntervalArith.Approx ⊑"
+  , valuesName: "interval approximations"
+  , fromArbitraryValue: \(ArbitraryApprox d) -> d
+  , leqOpWithInput: (assertOpWithInput (⊑) " ⊑ ")
+  , leqOpSymbol: "⊑"
+  , eqOpWithInput: (assertOpWithInput (==) " == ")
+  , eqOpSymbol: "="
+  }

--- a/test/IntervalArith/Approx/Approx.purs
+++ b/test/IntervalArith/Approx/Approx.purs
@@ -5,7 +5,7 @@ module Test.IntervalArith.Approx
 import Prelude
 
 import Effect (Effect)
-import IntervalArith.Approx (Approx, approxMB, better, setMB, (⊑))
+import IntervalArith.Approx (Approx(..), approxMB, better, setMB, (⊑))
 import IntervalArith.Approx.ShowA (showA)
 import IntervalArith.Misc (big)
 import Test.IntervalArith.Approx.ShowA (approxTests_showA)
@@ -15,6 +15,7 @@ import Test.QuickCheck (class Arbitrary, arbitrary)
 import Test.QuickCheck.Gen (Size, chooseInt, randomSample', sized)
 import Test.TestUtils (SuiteOrdParams1, assertOp, assertOpWithInput)
 import Test.Unit (TestSuite, suite, test)
+import Test.Unit.Assert (equal)
 import Test.Unit.QuickCheck (quickCheck)
 
 data ArbitraryApprox
@@ -55,7 +56,20 @@ approxTests_setMBworse =
             assertOp (flip better) " ⊒ " aMB a
 
 approxTests_Order :: TestSuite
-approxTests_Order = preOrderTests approxOrdParams
+approxTests_Order = 
+  suite "IntervalArith.Approx - approximation order (`better`)" do
+    test "SHOULD give (Approx 4 12 1 3 = 96±8 \"1~~\") WHEN setMB 4 (Approx 10 100 0 0 ~ \"100\")" do
+      let
+        -- given
+        input = Approx 10 (big 100) (big 0) 0
+
+        -- when
+        result = Approx 4 (big 12) (big 1) 3
+
+        -- then
+        expected = result
+      equal expected result
+    preOrderTests approxOrdParams
 
 approxOrdParams :: SuiteOrdParams1 ArbitraryApprox Approx
 approxOrdParams =

--- a/test/IntervalArith/Approx/Approx.purs
+++ b/test/IntervalArith/Approx/Approx.purs
@@ -5,16 +5,17 @@ module Test.IntervalArith.Approx
 import Prelude
 
 import Effect (Effect)
-import IntervalArith.Approx (Approx, approxMB, (⊑))
+import IntervalArith.Approx (Approx, approxMB, better, setMB, (⊑))
 import IntervalArith.Approx.ShowA (showA)
 import IntervalArith.Misc (big)
 import Test.IntervalArith.Approx.ShowA (approxTests_showA)
-import Test.IntervalArith.Misc (ArbitraryInteger(..))
+import Test.IntervalArith.Misc (ArbitraryInteger(..), ArbitraryPositiveExponent(..))
 import Test.Order (preOrderTests)
 import Test.QuickCheck (class Arbitrary, arbitrary)
 import Test.QuickCheck.Gen (Size, chooseInt, randomSample', sized)
-import Test.TestUtils (SuiteOrdParams1, assertOpWithInput)
-import Test.Unit (TestSuite)
+import Test.TestUtils (SuiteOrdParams1, assertOp, assertOpWithInput)
+import Test.Unit (TestSuite, suite, test)
+import Test.Unit.QuickCheck (quickCheck)
 
 data ArbitraryApprox
   = ArbitraryApprox Approx
@@ -28,13 +29,30 @@ instance arbitraryApprox :: Arbitrary ArbitraryApprox where
       pure $ ArbitraryApprox $ approxMB mb m (big 0) s
 
 randomSampleApprox :: Size -> Effect (Array String)
-randomSampleApprox size = 
-  randomSample' size (map (\(ArbitraryApprox a) -> a) arbitrary) >>= \as -> pure (map showA as)
+randomSampleApprox size = randomSample' size (map (\(ArbitraryApprox a) -> a) arbitrary) >>= \as -> pure (map showA as)
 
 approxTests :: TestSuite
 approxTests = do
   approxTests_showA
+  approxTests_setMBworse
   approxTests_Order
+
+approxTests_setMBworse :: TestSuite
+approxTests_setMBworse =
+  suite "IntervalArith.Approx - setMB" do
+    test "SHOULD HOLD setMB mb a ⊒ a FOR ALL approx a and integer mb>=0"
+      $ quickCheck \aPre mbPre ->
+          let
+            -- given
+            (ArbitraryApprox a) = aPre
+
+            (ArbitraryPositiveExponent mb) = mbPre
+
+            -- when
+            aMB = setMB mb a
+          -- then
+          in
+            assertOp (flip better) " ⊒ " aMB a
 
 approxTests_Order :: TestSuite
 approxTests_Order = preOrderTests approxOrdParams

--- a/test/IntervalArith/Approx/Approx.purs
+++ b/test/IntervalArith/Approx/Approx.purs
@@ -1,15 +1,18 @@
 module Test.IntervalArith.Approx
-  ( approxTests
+  ( approxTests, ArbitraryApprox(..), randomSampleApprox
   ) where
 
 import Prelude
+
+import Effect (Effect)
 import IntervalArith.Approx (Approx, approxMB, (⊑))
+import IntervalArith.Approx.ShowA (showA)
 import IntervalArith.Misc (big)
 import Test.IntervalArith.Approx.ShowA (approxTests_showA)
 import Test.IntervalArith.Misc (ArbitraryInteger(..))
 import Test.Order (preOrderTests)
 import Test.QuickCheck (class Arbitrary, arbitrary)
-import Test.QuickCheck.Gen (chooseInt, sized)
+import Test.QuickCheck.Gen (Size, chooseInt, randomSample', sized)
 import Test.TestUtils (SuiteOrdParams1, assertOpWithInput)
 import Test.Unit (TestSuite)
 
@@ -21,8 +24,12 @@ instance arbitraryApprox :: Arbitrary ArbitraryApprox where
     sized \size -> do
       (ArbitraryInteger m) <- arbitrary
       s <- chooseInt (-2 * size) (2 * size)
-      mb <- chooseInt 2 (10 + 2 * size)
+      mb <- chooseInt 10 (10 + 2 * size)
       pure $ ArbitraryApprox $ approxMB mb m (big 0) s
+
+randomSampleApprox :: Size -> Effect (Array String)
+randomSampleApprox size = 
+  randomSample' size (map (\(ArbitraryApprox a) -> a) arbitrary) >>= \as -> pure (map showA as)
 
 approxTests :: TestSuite
 approxTests = do

--- a/test/IntervalArith/Approx/Approx.purs
+++ b/test/IntervalArith/Approx/Approx.purs
@@ -4,7 +4,7 @@ module Test.IntervalArith.Approx
 
 import Prelude
 import Effect (Effect)
-import IntervalArith.Approx (Approx(..), approxMB, setMB, (⊑))
+import IntervalArith.Approx (Approx(..), approxMB, consistent, setMB, (⊑))
 import IntervalArith.Approx.ShowA (showA)
 import IntervalArith.Misc (big)
 import Test.IntervalArith.Approx.ShowA (approxTests_showA)
@@ -36,6 +36,7 @@ approxTests = do
   approxTests_showA
   approxTests_setMBworse
   approxTests_Order
+  approxTests_Consistent
 
 approxTests_setMBworse :: TestSuite
 approxTests_setMBworse =
@@ -69,6 +70,34 @@ approxTests_Order =
         expected = result
       equal expected result
     preOrderTests approxOrdParams
+
+approxTests_Consistent :: TestSuite
+approxTests_Consistent =
+  suite "IntervalArith.Approx - consistency check (`consistent`)" do
+    test "SHOULD HOLD consistent (Approx 4 12 1 3 = 96±8) (Approx 4 13 1 3 = 104±8)" do
+      let
+        -- given
+        input1 = Approx 4 (big 12) (big 1) 3
+
+        input2 = Approx 4 (big 12) (big 1) 3
+
+        -- when
+        result = consistent input1 input2
+      -- then
+      equal result true
+    test "SHOULD HOLD consistent a b WHEN a ⊑ b FOR ALL approx a b"
+      $ quickCheck \aPre bPre ->
+          let
+            -- given
+            (ArbitraryApprox b) = bPre
+
+            (ArbitraryApprox a1) = aPre
+
+            -- when
+            a = approxOrdParams.makeLeq b a1
+          -- then
+          in
+            assertOp consistent " `consistent` " a b
 
 approxOrdParams :: SuiteOrdParams1 ArbitraryApprox Approx
 approxOrdParams =

--- a/test/IntervalArith/Approx/Approx.purs
+++ b/test/IntervalArith/Approx/Approx.purs
@@ -8,12 +8,12 @@ import Effect (Effect)
 import IntervalArith.Approx (Approx(..), approxMB, consistent, setMB, (⊑))
 import IntervalArith.Approx.ShowA (showA)
 import IntervalArith.Misc (big)
+import Test.Field (fieldTests)
 import Test.IntervalArith.Approx.ShowA (approxTests_showA)
 import Test.IntervalArith.Misc (ArbitraryInteger(..), ArbitraryPositiveExponent(..))
 import Test.Order (preOrderTests)
 import Test.QuickCheck (class Arbitrary, arbitrary)
 import Test.QuickCheck.Gen (Size, chooseInt, randomSample', sized)
-import Test.Ring (commutativeRingTests)
 import Test.TestUtils (SuiteOrdParams1, SuiteEqParams1, assertOp, assertOpWithInput)
 import Test.Unit (TestSuite, suite, test)
 import Test.Unit.Assert (equal)
@@ -39,7 +39,7 @@ approxTests = do
   approxTests_setMBworse
   approxTests_Order
   approxTests_Consistent
-  approxTests_Ring
+  approxTests_Field
 
 approxTests_setMBworse :: TestSuite
 approxTests_setMBworse =
@@ -102,8 +102,8 @@ approxTests_Consistent =
           in
             assertOp consistent " `consistent` " a b
 
-approxTests_Ring :: TestSuite
-approxTests_Ring = commutativeRingTests approxEqParams
+approxTests_Field :: TestSuite
+approxTests_Field = fieldTests approxEqParams
 
 approxOrdParams :: SuiteOrdParams1 ArbitraryApprox Approx
 approxOrdParams =

--- a/test/IntervalArith/Approx/ShowA.purs
+++ b/test/IntervalArith/Approx/ShowA.purs
@@ -1,5 +1,5 @@
 module Test.IntervalArith.Approx.ShowA
-  ( showATests
+  ( approxTests_showA
   ) where
 
 import Prelude
@@ -12,8 +12,8 @@ import Test.Unit (TestSuite, suite, test)
 import Test.Unit.Assert (equal)
 import Test.Unit.QuickCheck (quickCheck)
 
-showATests :: TestSuite
-showATests =
+approxTests_showA :: TestSuite
+approxTests_showA =
   suite "IntervalArith.Approx - showA" do
     test "SHOULD show '1' WHEN Approx 1 1 0 0" do
       let

--- a/test/IntervalArith/Dyadic.purs
+++ b/test/IntervalArith/Dyadic.purs
@@ -24,7 +24,7 @@ instance arbitraryDyadic :: Arbitrary ArbitraryDyadic where
 
 dyadicTests :: TestSuite
 dyadicTests =
-  suite "IntervalArith.Misc - Dyadic arithmetic" do
+  suite "IntervalArith.Dyadic - arithmetic" do
     dyadicTests_Order
     dyadicTests_Ring
     dyadicTests_Scaling
@@ -32,7 +32,7 @@ dyadicTests =
 
 dyadicTests_Scaling :: TestSuite
 dyadicTests_Scaling =
-  suite "IntervalArith.Misc - Dyadic scaling by powers of 2" do
+  suite "IntervalArith.Dyadic - scaling by powers of 2" do
     test "SHOULD HOLD n = scale (scale n i) (-i) FOR ALL integers n and i>=0"
       $ quickCheck \dPre iPre ->
           let
@@ -69,7 +69,7 @@ dyadicTests_Order = totalOrderTests dyadicOrdParams
 
 dyadicTests_ToRational :: TestSuite
 dyadicTests_ToRational =
-  suite "IntervalArith.Misc - Dyadic conversion to Rational" do
+  suite "IntervalArith.Dyadic - conversion to Rational" do
     test "SHOULD HOLD Q(d1 + d2) = Q(d1) + Q(d2) FOR ALL dyadic numbers d1, d2"
       $ quickCheck \d1Pre d2Pre ->
           let
@@ -88,7 +88,7 @@ dyadicTests_ToRational =
 
 dyadicOrdParams :: SuiteOrdParams1 ArbitraryDyadic Dyadic
 dyadicOrdParams =
-  { suitePrefix: "IntervalArith.Misc - Dyadic <="
+  { suitePrefix: "IntervalArith.Dyadic - <="
   , valuesName: "dyadic numbers"
   , fromArbitraryValue: \(ArbitraryDyadic d) -> d
   , leqOpWithInput: (assertOpWithInput (<=) " <= ")
@@ -102,7 +102,7 @@ dyadicTests_Ring = commutativeRingTests dyadicEqParams
 
 dyadicEqParams :: SuiteEqParams1 ArbitraryDyadic Dyadic
 dyadicEqParams =
-  { suitePrefix: "IntervalArith.Misc - Dyadic"
+  { suitePrefix: "IntervalArith.Dyadic -"
   , valuesName: "dyadic numbers"
   , fromArbitraryValue: \(ArbitraryDyadic d) -> d
   , eqOpWithInput: (assertOpWithInput (==) " == ")

--- a/test/IntervalArith/Dyadic.purs
+++ b/test/IntervalArith/Dyadic.purs
@@ -95,6 +95,7 @@ dyadicOrdParams =
   , leqOpSymbol: "<="
   , eqOpWithInput: (assertOpWithInput (==) " == ")
   , eqOpSymbol: "="
+  , makeLeq: \ a b -> b
   }
 
 dyadicTests_Ring :: TestSuite

--- a/test/Order.purs
+++ b/test/Order.purs
@@ -32,110 +32,114 @@ preOrderTests params =
 
 reflexivity ::
   forall at t. Arbitrary at => SuiteOrdParams1 at t -> TestSuite
-reflexivity { suitePrefix, valuesName, fromArbitraryValue, leqOpWithInput, leqOpSymbol, eqOpWithInput, eqOpSymbol } =
+reflexivity p =
   test
     ( "SHOULD HOLD reflexivity: "
         <> "a"
-        <> leqOpSymbol
+        <> p.leqOpSymbol
         <> "a"
         <> " FOR ALL "
-        <> valuesName
+        <> p.valuesName
         <> " a"
     )
     $ quickCheck \aA ->
         let
-          a = fromArbitraryValue aA
+          a = p.fromArbitraryValue aA
 
-          leqOp = leqOpWithInput [ a ]
+          leqOp = p.leqOpWithInput [ a ]
         in
-          (a) `leqOp` (a)
+          a `leqOp` a
 
 connexity ::
   forall at t. Arbitrary at => SuiteOrdParams1 at t -> TestSuite
-connexity { suitePrefix, valuesName, fromArbitraryValue, leqOpWithInput, leqOpSymbol, eqOpWithInput, eqOpSymbol } =
+connexity p =
   test
     ( "SHOULD HOLD connexity: "
         <> "a"
-        <> leqOpSymbol
+        <> p.leqOpSymbol
         <> "b"
         <> " or "
         <> "b"
-        <> leqOpSymbol
+        <> p.leqOpSymbol
         <> "a"
         <> " FOR ALL "
-        <> valuesName
+        <> p.valuesName
         <> " a,b"
     )
     $ quickCheck \aA bA ->
         let
-          a = fromArbitraryValue aA
+          a = p.fromArbitraryValue aA
 
-          b = fromArbitraryValue bA
+          b = p.fromArbitraryValue bA
 
-          leqOp = leqOpWithInput [ a, b ]
+          leqOp = p.leqOpWithInput [ a, b ]
         in
           (a `leqOp` b) |=| (b `leqOp` a)
 
 antisymmetry ::
   forall at t. Arbitrary at => SuiteOrdParams1 at t -> TestSuite
-antisymmetry { suitePrefix, valuesName, fromArbitraryValue, leqOpWithInput, leqOpSymbol, eqOpWithInput, eqOpSymbol } =
+antisymmetry p =
   test
     ( "SHOULD HOLD antisymmetry: "
         <> "a"
-        <> leqOpSymbol
+        <> p.leqOpSymbol
         <> "b"
         <> " and "
         <> "b"
-        <> leqOpSymbol
+        <> p.leqOpSymbol
         <> "a"
         <> " implies "
         <> "a"
-        <> eqOpSymbol
+        <> p.eqOpSymbol
         <> "b"
         <> " FOR ALL "
-        <> valuesName
+        <> p.valuesName
         <> " a,b"
     )
     $ quickCheck \aA bA ->
         let
-          a = fromArbitraryValue aA
+          a = p.fromArbitraryValue aA
 
-          b = fromArbitraryValue bA
+          b1 = p.fromArbitraryValue bA
 
-          eqOp = eqOpWithInput [ a, b ]
+          b2 = p.makeLeq a b1
 
-          leqOp = leqOpWithInput [ a, b ]
+          b = p.makeLeq b1 b2
+
+          eqOp = p.eqOpWithInput [ a, b ]
+
+          leqOp = p.leqOpWithInput [ a, b ]
         in
           ((a `leqOp` b) &=& (b `leqOp` a)) ==> (a `eqOp` b)
 
 transitivity ::
   forall at t. Arbitrary at => SuiteOrdParams1 at t -> TestSuite
-transitivity { suitePrefix, valuesName, fromArbitraryValue, leqOpWithInput, leqOpSymbol, eqOpWithInput, eqOpSymbol } =
+transitivity p =
   test
     ( "SHOULD HOLD transitivity: "
         <> "a"
-        <> leqOpSymbol
+        <> p.leqOpSymbol
         <> "b"
         <> " and "
         <> "b"
-        <> leqOpSymbol
+        <> p.leqOpSymbol
         <> "c"
         <> " implies "
         <> "a"
-        <> leqOpSymbol
+        <> p.leqOpSymbol
         <> "c"
         <> " FOR ALL "
-        <> valuesName
+        <> p.valuesName
         <> " a,b,c"
     )
     $ quickCheck \aA bA cA ->
         let
-          a = fromArbitraryValue aA
+          c = p.fromArbitraryValue cA
 
-          b = fromArbitraryValue bA
+          b = p.makeLeq c $ p.fromArbitraryValue bA
 
-          c = fromArbitraryValue cA
+          a = p.makeLeq b $ p.fromArbitraryValue aA
 
-          leqOp = leqOpWithInput [ a, b, c ]
+          leqOp = p.leqOpWithInput [ a, b, c ]
         in
           ((a `leqOp` b) &=& (b `leqOp` c)) ==> (a `leqOp` c)

--- a/test/Order.purs
+++ b/test/Order.purs
@@ -1,7 +1,6 @@
 module Test.Order where
 
 import Prelude
-
 import Test.QuickCheck (class Arbitrary)
 import Test.QuickCheck.Combinators ((&=&), (==>), (|=|))
 import Test.TestUtils (SuiteOrdParams1)
@@ -76,7 +75,6 @@ connexity { suitePrefix, valuesName, fromArbitraryValue, leqOpWithInput, leqOpSy
           leqOp = leqOpWithInput [ a, b ]
         in
           (a `leqOp` b) |=| (b `leqOp` a)
-
 
 antisymmetry ::
   forall at t. Arbitrary at => SuiteOrdParams1 at t -> TestSuite

--- a/test/Order.purs
+++ b/test/Order.purs
@@ -1,29 +1,38 @@
 module Test.Order where
 
 import Prelude
+
 import Test.QuickCheck (class Arbitrary)
-import Test.QuickCheck.Combinators ((&=&), (==>))
+import Test.QuickCheck.Combinators ((&=&), (==>), (|=|))
 import Test.TestUtils (SuiteOrdParams1)
 import Test.Unit (TestSuite, suite, test)
 import Test.Unit.QuickCheck (quickCheck)
 
 totalOrderTests ::
-  forall at t. Arbitrary at => CommutativeRing t => SuiteOrdParams1 at t -> TestSuite
+  forall at t. Arbitrary at => SuiteOrdParams1 at t -> TestSuite
 totalOrderTests params = do
   suite (params.suitePrefix <> " is a total order") do
-    reflexivity params
+    connexity params
     transitivity params
     antisymmetry params
 
 partialOrderTests ::
-  forall at t. Arbitrary at => CommutativeRing t => SuiteOrdParams1 at t -> TestSuite
+  forall at t. Arbitrary at => SuiteOrdParams1 at t -> TestSuite
 partialOrderTests params =
+  suite (params.suitePrefix <> " is a partial order") do
+    reflexivity params
+    transitivity params
+    antisymmetry params
+
+preOrderTests ::
+  forall at t. Arbitrary at => SuiteOrdParams1 at t -> TestSuite
+preOrderTests params =
   suite (params.suitePrefix <> " is a partial order") do
     reflexivity params
     transitivity params
 
 reflexivity ::
-  forall at t. Arbitrary at => CommutativeRing t => SuiteOrdParams1 at t -> TestSuite
+  forall at t. Arbitrary at => SuiteOrdParams1 at t -> TestSuite
 reflexivity { suitePrefix, valuesName, fromArbitraryValue, leqOpWithInput, leqOpSymbol, eqOpWithInput, eqOpSymbol } =
   test
     ( "SHOULD HOLD reflexivity: "
@@ -42,8 +51,35 @@ reflexivity { suitePrefix, valuesName, fromArbitraryValue, leqOpWithInput, leqOp
         in
           (a) `leqOp` (a)
 
+connexity ::
+  forall at t. Arbitrary at => SuiteOrdParams1 at t -> TestSuite
+connexity { suitePrefix, valuesName, fromArbitraryValue, leqOpWithInput, leqOpSymbol, eqOpWithInput, eqOpSymbol } =
+  test
+    ( "SHOULD HOLD connexity: "
+        <> "a"
+        <> leqOpSymbol
+        <> "b"
+        <> " or "
+        <> "b"
+        <> leqOpSymbol
+        <> "a"
+        <> " FOR ALL "
+        <> valuesName
+        <> " a,b"
+    )
+    $ quickCheck \aA bA ->
+        let
+          a = fromArbitraryValue aA
+
+          b = fromArbitraryValue bA
+
+          leqOp = leqOpWithInput [ a, b ]
+        in
+          (a `leqOp` b) |=| (b `leqOp` a)
+
+
 antisymmetry ::
-  forall at t. Arbitrary at => CommutativeRing t => SuiteOrdParams1 at t -> TestSuite
+  forall at t. Arbitrary at => SuiteOrdParams1 at t -> TestSuite
 antisymmetry { suitePrefix, valuesName, fromArbitraryValue, leqOpWithInput, leqOpSymbol, eqOpWithInput, eqOpSymbol } =
   test
     ( "SHOULD HOLD antisymmetry: "
@@ -75,7 +111,7 @@ antisymmetry { suitePrefix, valuesName, fromArbitraryValue, leqOpWithInput, leqO
           ((a `leqOp` b) &=& (b `leqOp` a)) ==> (a `eqOp` b)
 
 transitivity ::
-  forall at t. Arbitrary at => CommutativeRing t => SuiteOrdParams1 at t -> TestSuite
+  forall at t. Arbitrary at => SuiteOrdParams1 at t -> TestSuite
 transitivity { suitePrefix, valuesName, fromArbitraryValue, leqOpWithInput, leqOpSymbol, eqOpWithInput, eqOpSymbol } =
   test
     ( "SHOULD HOLD transitivity: "

--- a/test/Order.purs
+++ b/test/Order.purs
@@ -27,7 +27,7 @@ partialOrderTests params =
 preOrderTests ::
   forall at t. Arbitrary at => SuiteOrdParams1 at t -> TestSuite
 preOrderTests params =
-  suite (params.suitePrefix <> " is a partial order") do
+  suite (params.suitePrefix <> " is a pre-order") do
     reflexivity params
     transitivity params
 

--- a/test/Ring.purs
+++ b/test/Ring.purs
@@ -19,195 +19,195 @@ commutativeRingTests params =
 -- distributiveRules params
 commutativeMonoidAddition ::
   forall at t. Arbitrary at => Semiring t => SuiteEqParams1 at t -> TestSuite
-commutativeMonoidAddition { suitePrefix, valuesName, fromArbitraryValue, eqOpWithInput, eqOpSymbol } =
-  suite (suitePrefix <> " forms a commutative monoid under addition") do
+commutativeMonoidAddition p =
+  suite (p.suitePrefix <> " forms a commutative monoid under addition") do
     test
       ( "SHOULD HOLD associativity: (a + b) + c "
-          <> eqOpSymbol
+          <> p.eqOpSymbol
           <> " a + (b + c) FOR ALL "
-          <> valuesName
+          <> p.valuesName
           <> " a, b, c"
       )
       $ quickCheck \aA bA cA ->
           let
-            a = fromArbitraryValue aA
+            a = p.fromArbitraryValue aA
 
-            b = fromArbitraryValue bA
+            b = p.fromArbitraryValue bA
 
-            c = fromArbitraryValue cA
+            c = p.fromArbitraryValue cA
 
-            eqOp = eqOpWithInput [ a, b, c ]
+            eqOp = p.eqOpWithInput [ a, b, c ]
           in
             ((a + b) + c) `eqOp` (a + (b + c))
     test
       ( "SHOULD HOLD identity: zero + a "
-          <> eqOpSymbol
+          <> p.eqOpSymbol
           <> " a + zero "
-          <> eqOpSymbol
+          <> p.eqOpSymbol
           <> " a "
           <> "FOR ALL "
-          <> valuesName
+          <> p.valuesName
           <> " a"
       )
       $ quickCheck \aA ->
           let
-            a = fromArbitraryValue aA
+            a = p.fromArbitraryValue aA
 
-            eqOp = eqOpWithInput [ a ]
+            eqOp = p.eqOpWithInput [ a ]
           in
             ((a + zero) `eqOp` a)
               &=& (a `eqOp` (a + zero))
     test
       ( "SHOULD HOLD commutativity: a + b "
-          <> eqOpSymbol
+          <> p.eqOpSymbol
           <> " b + a "
           <> "FOR ALL "
-          <> valuesName
+          <> p.valuesName
           <> " a, b"
       )
       $ quickCheck \aA bA ->
           let
-            a = fromArbitraryValue aA
+            a = p.fromArbitraryValue aA
 
-            b = fromArbitraryValue bA
+            b = p.fromArbitraryValue bA
 
-            eqOp = eqOpWithInput [ a, b ]
+            eqOp = p.eqOpWithInput [ a, b ]
           in
             (a + b) `eqOp` (b + a)
 
 commutativeMonoidMultiplication ::
   forall at t. Arbitrary at => CommutativeRing t => SuiteEqParams1 at t -> TestSuite
-commutativeMonoidMultiplication { suitePrefix, valuesName, fromArbitraryValue, eqOpWithInput, eqOpSymbol } =
-  suite (suitePrefix <> " forms a commutative monoid under multiplication") do
+commutativeMonoidMultiplication p =
+  suite (p.suitePrefix <> " forms a commutative monoid under multiplication") do
     test
       ( "SHOULD HOLD associativity: (a * b) * c "
-          <> eqOpSymbol
+          <> p.eqOpSymbol
           <> " a * (b * c) FOR ALL "
-          <> valuesName
+          <> p.valuesName
           <> " a, b, c"
       )
       $ quickCheck \aA bA cA ->
           let
-            a = fromArbitraryValue aA
+            a = p.fromArbitraryValue aA
 
-            b = fromArbitraryValue bA
+            b = p.fromArbitraryValue bA
 
-            c = fromArbitraryValue cA
+            c = p.fromArbitraryValue cA
 
-            eqOp = eqOpWithInput [ a, b, c ]
+            eqOp = p.eqOpWithInput [ a, b, c ]
           in
             ((a * b) * c) `eqOp` (a * (b * c))
     test
       ( "SHOULD HOLD identity: one * a "
-          <> eqOpSymbol
+          <> p.eqOpSymbol
           <> " a * one "
-          <> eqOpSymbol
+          <> p.eqOpSymbol
           <> " a "
           <> "FOR ALL "
-          <> valuesName
+          <> p.valuesName
           <> " a"
       )
       $ quickCheck \aA ->
           let
-            a = fromArbitraryValue aA
+            a = p.fromArbitraryValue aA
 
-            eqOp = eqOpWithInput [ a ]
+            eqOp = p.eqOpWithInput [ a ]
           in
             ((a * one) `eqOp` a)
               &=& (a `eqOp` (a * one))
     test
       ( "SHOULD HOLD commutativity: a * b "
-          <> eqOpSymbol
+          <> p.eqOpSymbol
           <> " b * a "
           <> "FOR ALL "
-          <> valuesName
+          <> p.valuesName
           <> " a, b"
       )
       $ quickCheck \aA bA ->
           let
-            a = fromArbitraryValue aA
+            a = p.fromArbitraryValue aA
 
-            b = fromArbitraryValue bA
+            b = p.fromArbitraryValue bA
 
-            eqOp = eqOpWithInput [ a, b ]
+            eqOp = p.eqOpWithInput [ a, b ]
           in
             (a * b) `eqOp` (b * a)
 
 distributiveLaws ::
   forall at t. Arbitrary at => Semiring t => SuiteEqParams1 at t -> TestSuite
-distributiveLaws { suitePrefix, valuesName, fromArbitraryValue, eqOpWithInput, eqOpSymbol } =
-  suite (suitePrefix <> " satisfies semiring distributive laws") do
+distributiveLaws p =
+  suite (p.suitePrefix <> " satisfies semiring distributive laws") do
     test
       ( "SHOULD HOLD left distributivity: a * (b + c) "
-          <> eqOpSymbol
+          <> p.eqOpSymbol
           <> " (a * b) + (a * c) FOR ALL "
-          <> valuesName
+          <> p.valuesName
           <> " a, b, c"
       )
       $ quickCheck \aA bA cA ->
           let
-            a = fromArbitraryValue aA
+            a = p.fromArbitraryValue aA
 
-            b = fromArbitraryValue bA
+            b = p.fromArbitraryValue bA
 
-            c = fromArbitraryValue cA
+            c = p.fromArbitraryValue cA
 
-            eqOp = eqOpWithInput [ a, b, c ]
+            eqOp = p.eqOpWithInput [ a, b, c ]
           in
             (a * (b + c)) `eqOp` ((a * b) + (a * c))
     test
       ( "SHOULD HOLD right distributivity: (a + b) * c "
-          <> eqOpSymbol
+          <> p.eqOpSymbol
           <> " (a * c) + (b * c) FOR ALL "
-          <> valuesName
+          <> p.valuesName
           <> " a, b, c"
       )
       $ quickCheck \aA bA cA ->
           let
-            a = fromArbitraryValue aA
+            a = p.fromArbitraryValue aA
 
-            b = fromArbitraryValue bA
+            b = p.fromArbitraryValue bA
 
-            c = fromArbitraryValue cA
+            c = p.fromArbitraryValue cA
 
-            eqOp = eqOpWithInput [ a, b, c ]
+            eqOp = p.eqOpWithInput [ a, b, c ]
           in
             ((a + b) * c) `eqOp` ((a * c) + (b * c))
 
 otherLaws ::
   forall at t. Arbitrary at => CommutativeRing t => SuiteEqParams1 at t -> TestSuite
-otherLaws { suitePrefix, valuesName, fromArbitraryValue, eqOpWithInput, eqOpSymbol } =
-  suite (suitePrefix <> " satisfies other ring laws") do
+otherLaws p =
+  suite (p.suitePrefix <> " satisfies other ring laws") do
     test
       ( "SHOULD HOLD additive inverse: a - a "
-          <> eqOpSymbol
+          <> p.eqOpSymbol
           <> " (zero - a) + a "
-          <> eqOpSymbol
+          <> p.eqOpSymbol
           <> " zero "
           <> "FOR ALL "
-          <> valuesName
+          <> p.valuesName
           <> " a"
       )
       $ quickCheck \aA ->
           let
-            a = fromArbitraryValue aA
+            a = p.fromArbitraryValue aA
 
-            eqOp = eqOpWithInput [ a ]
+            eqOp = p.eqOpWithInput [ a ]
           in
             ((a - a) `eqOp` zero)
               &=& (((zero - a) + a) `eqOp` zero)
     test
       ( "SHOULD HOLD annihilation: zero * a "
-          <> eqOpSymbol
+          <> p.eqOpSymbol
           <> " zero "
           <> "FOR ALL "
-          <> valuesName
+          <> p.valuesName
           <> " a"
       )
       $ quickCheck \aA ->
           let
-            a = fromArbitraryValue aA
+            a = p.fromArbitraryValue aA
 
-            eqOp = eqOpWithInput [ a ]
+            eqOp = p.eqOpWithInput [ a ]
           in
             (zero * a) `eqOp` zero

--- a/test/TestUtils.purs
+++ b/test/TestUtils.purs
@@ -52,3 +52,6 @@ assertOpWithInput op opString input = assertOpMoreHelp op opString moreHelp
 
 eqWithInput :: forall t1 t2. Eq t2 => Show t2 => Show t1 => Array t1 -> t2 -> t2 -> Result
 eqWithInput = assertOpWithInput (==) " == "
+
+leqWithInput :: forall t1 t2. Ord t2 => Show t2 => Show t1 => Array t1 -> t2 -> t2 -> Result
+leqWithInput = assertOpWithInput (<=) " <= "

--- a/test/TestUtils.purs
+++ b/test/TestUtils.purs
@@ -20,6 +20,7 @@ type SuiteOrdParams1 at t
     , leqOpSymbol :: String
     , eqOpWithInput :: Array t -> (t -> t -> Result)
     , eqOpSymbol :: String
+    , makeLeq :: t -> t -> t -- ^ `(makeLeq a b) <= a` and `(makeLeq a b)` should be similar to `b`
     }
 
 -- copied from source code of purescript-quickcheck Test.QuickCheck.


### PR DESCRIPTION
# Issues
closes #9 
closes #20 

# Summary of changes
- conversions from Integer, Dyadic and Rational to Approx
- comparing two Approx for consistency (`consistent`) and for containment (`better`)
- getting bounds for an Approx as Dyadic, Rational or Number
- operations +,-,*,/ as well as constants zero and one satisfying all field laws

# Tests
- testing some properties of `better`, `consistent` and conversions from Integer and Rational
- generic tests of Field laws
- tests of Field laws for Approx field operations where equality is replaced by `consistent`
- test that Dyadic -> Number conversion preserves ordering
- improved generic Order laws, including a major bugfix
