### PR TITLE
Added evaluation to Approx

### DIFF
--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
 
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -28,4 +28,4 @@ jobs:
     - name: Test
       run: | 
         cd /home/runner/work/robust-plots/robust-plots
-#        npm run test
+        npm run test

--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -14,10 +14,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Setup Node.js 10
+    - name: Setup Node.js 12
       uses: actions/setup-node@v1
       with:
-        node-version: 10
+        node-version: 12
 
     - name: Install spago and load dependencies
       run: npm install

--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -20,12 +20,7 @@ jobs:
         node-version: 10
 
     - name: Install spago and load dependencies
-      run: |
-        npm install spago -g
-        cd /home/runner/work/robust-plots/robust-plots
-        npm run install
+      run: npm install
 
     - name: Test
-      run: | 
-        cd /home/runner/work/robust-plots/robust-plots
-        npm run test
+      run: npm run test

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
     "decimal.js": "7.1.1"
   },
   "devDependencies": {
-    "spago": "^0.15.2",
-    "parcel": "^2.0.0-nightly.259"
+    "spago": "^0.15.3",
+    "parcel": "^2.0.0-nightly.291"
   },
   "license": "BSD-3-Clause"
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   },
   "devDependencies": {
     "spago": "^0.15.3",
-    "parcel": "^2.0.0-nightly.291"
+    "parcel": "^2.0.0-nightly.291",
+    "purescript": "^0.13.8"
   },
   "license": "BSD-3-Clause"
 }

--- a/src/Components/ExpressionInput/ExpressionInput.purs
+++ b/src/Components/ExpressionInput/ExpressionInput.purs
@@ -8,7 +8,7 @@ import Data.Maybe (Maybe(..), fromMaybe)
 import Data.Tuple (Tuple(..))
 import Effect.Class (class MonadEffect)
 import Expression.Error (Expect)
-import Expression.Evaluator (evaluate, presetConstants)
+import Expression.Evaluator (roughEvaluate, presetConstants)
 import Expression.Syntax (Expression)
 import Halogen as H
 import Halogen.HTML as HH
@@ -96,4 +96,4 @@ handleAction controller = case _ of
     pure unit
 
 checkExpression :: Expression -> Expect Number
-checkExpression expression = evaluate (presetConstants <> [ Tuple "x" 0.0 ]) expression
+checkExpression expression = roughEvaluate (presetConstants <> [ Tuple "x" 0.0 ]) expression

--- a/src/Expression/Differentiator.purs
+++ b/src/Expression/Differentiator.purs
@@ -4,15 +4,15 @@ import Prelude
 
 import Expression.SubExpression (removeSubExpressions)
 import Expression.Syntax (BinaryOperation(..), Expression(..), UnaryOperation(..))
-import IntervalArith.Misc (toRational)
+import IntervalArith.Misc (Rational)
 
 secondDifferentiate :: Expression -> Expression
 secondDifferentiate = differentiate <<< differentiate
 
 differentiate :: Expression -> Expression
 differentiate = case _ of
-  ExpressionLiteral _ -> ExpressionLiteral $ toRational 0
-  ExpressionVariable _ -> ExpressionLiteral $ toRational 1
+  ExpressionLiteral _ -> ExpressionLiteral zero
+  ExpressionVariable _ -> ExpressionLiteral one
   ExpressionBinary operation leftExpression rightExpression -> differentiateBinaryOperation operation leftExpression rightExpression
   ExpressionUnary operation expression -> differentiateUnaryOperation operation expression
   ExpressionLet name expression parentExpression -> differentiate $ removeSubExpressions $ ExpressionLet name expression parentExpression
@@ -33,7 +33,7 @@ differentiateBinaryOperation (Times) leftExpression rightExpression = Expression
 
   v' = differentiate v
 
-differentiateBinaryOperation (Divide) topExpression bottomExpression = ExpressionBinary Divide (ExpressionBinary Minus (ExpressionBinary Times f' g) (ExpressionBinary Times f g')) (ExpressionBinary Power g (ExpressionLiteral (toRational 2)))
+differentiateBinaryOperation (Divide) topExpression bottomExpression = ExpressionBinary Divide (ExpressionBinary Minus (ExpressionBinary Times f' g) (ExpressionBinary Times f g')) (ExpressionBinary Power g (ExpressionLiteral two))
   -- Quotient rule
   where
   f = topExpression
@@ -44,11 +44,11 @@ differentiateBinaryOperation (Divide) topExpression bottomExpression = Expressio
 
   g' = differentiate g
 
-differentiateBinaryOperation (Power) (ExpressionVariable "e") (ExpressionLiteral _) = ExpressionLiteral $ toRational 0
+differentiateBinaryOperation (Power) (ExpressionVariable "e") (ExpressionLiteral _) = ExpressionLiteral zero
 
 differentiateBinaryOperation (Power) (ExpressionVariable "e") exponentExpression = ExpressionBinary Times (differentiate exponentExpression) (ExpressionUnary Exp exponentExpression)
 
-differentiateBinaryOperation (Power) baseExpression (ExpressionLiteral value) = ExpressionBinary Times (ExpressionLiteral value) (ExpressionBinary Power baseExpression (ExpressionLiteral (value - toRational 1)))
+differentiateBinaryOperation (Power) baseExpression (ExpressionLiteral value) = ExpressionBinary Times (ExpressionLiteral value) (ExpressionBinary Power baseExpression (ExpressionLiteral (value - one)))
 
 differentiateBinaryOperation (Power) baseExpression exponentExpression = ExpressionBinary Times k (ExpressionBinary Plus j l)
   -- (g^f)' = g^(f-1) * ((f*g')+(g*f'*log(g)))
@@ -64,7 +64,7 @@ differentiateBinaryOperation (Power) baseExpression exponentExpression = Express
   g' = differentiate g
 
   -- k = g^(f - 1)
-  k = ExpressionBinary Power g (ExpressionBinary Minus f (ExpressionLiteral (toRational (-1))))
+  k = ExpressionBinary Power g (ExpressionBinary Minus f (ExpressionLiteral (-one)))
 
   -- j = f * g'
   j = ExpressionBinary Times f g'
@@ -75,14 +75,14 @@ differentiateBinaryOperation (Power) baseExpression exponentExpression = Express
 differentiateUnaryOperation :: UnaryOperation -> Expression -> Expression
 differentiateUnaryOperation (Neg) expression = ExpressionUnary Neg $ differentiate expression
 
-differentiateUnaryOperation (Sqrt) expression = ExpressionBinary Divide f' (ExpressionBinary Times (ExpressionLiteral (toRational 2)) (ExpressionUnary Sqrt f))
+differentiateUnaryOperation (Sqrt) expression = ExpressionBinary Divide f' (ExpressionBinary Times (ExpressionLiteral two) (ExpressionUnary Sqrt f))
   -- (sqrt(f))' = f'/(2*sqrt(f))
   where
   f = expression
 
   f' = differentiate f
 
-differentiateUnaryOperation (Exp) (ExpressionLiteral _) = ExpressionLiteral $ toRational 0
+differentiateUnaryOperation (Exp) (ExpressionLiteral _) = ExpressionLiteral zero
 
 differentiateUnaryOperation (Exp) expression = ExpressionBinary Times (differentiate expression) (ExpressionUnary Exp expression)
 
@@ -92,7 +92,7 @@ differentiateUnaryOperation (Sine) expression = ExpressionBinary Times (differen
 
 differentiateUnaryOperation (Cosine) expression = ExpressionUnary Neg $ (ExpressionBinary Times (differentiate expression) (ExpressionUnary Sine expression))
 
-differentiateUnaryOperation (Tan) expression = ExpressionBinary Times f' (ExpressionBinary Plus (ExpressionLiteral (toRational 1)) k)
+differentiateUnaryOperation (Tan) expression = ExpressionBinary Times f' (ExpressionBinary Plus (ExpressionLiteral one) k)
   -- tan(f)' = f' * (1 + tan^2(f)) 
   -- tan(f)' = f' * (1 + k)
   where
@@ -101,4 +101,7 @@ differentiateUnaryOperation (Tan) expression = ExpressionBinary Times f' (Expres
   f' = differentiate f
 
   -- k = tan^2(f)
-  k = ExpressionBinary Power (ExpressionUnary Tan f) (ExpressionLiteral (toRational 2))
+  k = ExpressionBinary Power (ExpressionUnary Tan f) (ExpressionLiteral two)
+
+two :: Rational
+two = one + one

--- a/src/Expression/Error.purs
+++ b/src/Expression/Error.purs
@@ -8,10 +8,12 @@ import Data.Either (Either(..))
 data Error = ParseError String
            | UnknownValue VariableName
            | MultipleErrors String
+           | UnsupportedOperation String
 
 instance showError :: Show Error where
   show (ParseError s) = "Parse error: " <> s
   show (UnknownValue n) = "Unknown value: " <> n
+  show (UnsupportedOperation n) = "Unsupported operation: " <> n
   show (MultipleErrors msg) = msg     
 
 derive instance eqError :: Eq Error
@@ -29,3 +31,6 @@ unknownValue = throw <<< UnknownValue
 
 multipleErrors :: forall a. String -> Expect a
 multipleErrors = throw <<< MultipleErrors
+
+unsupportedOperation :: forall a. String -> Expect a
+unsupportedOperation = throw <<< UnsupportedOperation

--- a/src/Expression/Evaluator.purs
+++ b/src/Expression/Evaluator.purs
@@ -3,9 +3,10 @@ module Expression.Evaluator where
 import Data.Either (Either(..))
 import Data.Maybe (Maybe(..))
 import Data.Tuple (Tuple(..))
-import Expression.Error (Expect, unknownValue, multipleErrors, throw)
+import Expression.Error (Expect, multipleErrors, throw, unknownValue, unsupportedOperation)
 import Expression.Syntax (BinaryOperation(..), Expression(..), UnaryOperation(..))
 import Expression.VariableMap (VariableMap, lookup)
+import IntervalArith.Approx (Approx, fromRationalPrec)
 import IntervalArith.Misc (rationalToNumber)
 import Math (cos, exp, log, pow, sin, sqrt, tan, e, pi)
 import Prelude (add, div, mul, negate, pure, show, sub, ($), (<>))
@@ -13,19 +14,80 @@ import Prelude (add, div, mul, negate, pure, show, sub, ($), (<>))
 presetConstants :: Array (Tuple String Number)
 presetConstants = [ (Tuple "pi" pi), (Tuple "e" e) ]
 
-evaluate :: VariableMap Number -> Expression -> Expect Number
-evaluate variableMap = case _ of
+----------------------------------------------------
+-- Evaluate Number
+----------------------------------------------------
+roughEvaluate :: VariableMap Number -> Expression -> Expect Number
+roughEvaluate variableMap = case _ of
   ExpressionLiteral value -> pure $ rationalToNumber value
+  ExpressionVariable name -> case lookup variableMap name of
+    Just value -> pure value
+    _ -> unknownValue name
+  ExpressionBinary operation leftExpression rightExpression -> roughEvaluateBinaryOperation operation variableMap leftExpression rightExpression
+  ExpressionUnary operation expression -> roughEvaluateUnaryOperation operation variableMap expression
+  ExpressionLet name expression parentExpression -> case roughEvaluate variableMap expression of
+    Right value -> roughEvaluate (variableMap <> [ (Tuple name value) ]) parentExpression
+    Left error -> Left error
+
+roughEvaluateBinaryOperation :: BinaryOperation -> VariableMap Number -> Expression -> Expression -> Expect Number
+roughEvaluateBinaryOperation Plus = roughEvaluateArithmeticBinaryOperation add
+
+roughEvaluateBinaryOperation Minus = roughEvaluateArithmeticBinaryOperation sub
+
+roughEvaluateBinaryOperation Times = roughEvaluateArithmeticBinaryOperation mul
+
+roughEvaluateBinaryOperation Divide = roughEvaluateArithmeticBinaryOperation div
+
+roughEvaluateBinaryOperation Power = roughEvaluateArithmeticBinaryOperation pow
+
+roughEvaluateArithmeticBinaryOperation :: (Number -> Number -> Number) -> VariableMap Number -> Expression -> Expression -> Expect Number
+roughEvaluateArithmeticBinaryOperation operation variableMap leftExpression rightExpression = case roughEvaluate variableMap leftExpression, roughEvaluate variableMap rightExpression of
+  Right leftValue, Right rightValue -> pure $ operation leftValue rightValue
+  Left leftError, Left rightError -> multipleErrors $ (show leftError) <> " | " <> (show rightError)
+  Left leftError, _ -> throw leftError
+  _, Left rightError -> throw rightError
+
+roughEvaluateUnaryOperation :: UnaryOperation -> VariableMap Number -> Expression -> Expect Number
+roughEvaluateUnaryOperation (Neg) = roughEvaluateNegate
+
+roughEvaluateUnaryOperation (Sqrt) = roughEvaluateFunction sqrt
+
+roughEvaluateUnaryOperation (Exp) = roughEvaluateFunction exp
+
+roughEvaluateUnaryOperation (Log) = roughEvaluateFunction log
+
+roughEvaluateUnaryOperation (Sine) = roughEvaluateFunction sin
+
+roughEvaluateUnaryOperation (Cosine) = roughEvaluateFunction cos
+
+roughEvaluateUnaryOperation (Tan) = roughEvaluateFunction tan
+
+roughEvaluateFunction :: (Number -> Number) -> VariableMap Number -> Expression -> Expect Number
+roughEvaluateFunction op variableMap expression = case roughEvaluate variableMap expression of
+  Left error -> throw error
+  Right value -> pure $ op value
+
+roughEvaluateNegate :: VariableMap Number -> Expression -> Expect Number
+roughEvaluateNegate variableMap expression = case roughEvaluate variableMap expression of
+  Left error -> throw error
+  Right value -> pure $ -value
+
+----------------------------------------------------
+-- Evaluate Approx
+----------------------------------------------------
+evaluate :: VariableMap Approx -> Expression -> Expect Approx
+evaluate variableMap = case _ of
+  ExpressionLiteral value -> pure $ fromRationalPrec 4 value
   ExpressionVariable name -> case lookup variableMap name of
     Just value -> pure value
     _ -> unknownValue name
   ExpressionBinary operation leftExpression rightExpression -> evaluateBinaryOperation operation variableMap leftExpression rightExpression
   ExpressionUnary operation expression -> evaluateUnaryOperation operation variableMap expression
   ExpressionLet name expression parentExpression -> case evaluate variableMap expression of
-      Right value -> evaluate (variableMap <> [ (Tuple name value) ]) parentExpression
-      Left error -> Left error
+    Right value -> evaluate (variableMap <> [ (Tuple name value) ]) parentExpression
+    Left error -> Left error
 
-evaluateBinaryOperation :: BinaryOperation -> VariableMap Number -> Expression -> Expression -> Expect Number
+evaluateBinaryOperation :: BinaryOperation -> VariableMap Approx -> Expression -> Expression -> Expect Approx
 evaluateBinaryOperation Plus = evaluateArithmeticBinaryOperation add
 
 evaluateBinaryOperation Minus = evaluateArithmeticBinaryOperation sub
@@ -34,36 +96,36 @@ evaluateBinaryOperation Times = evaluateArithmeticBinaryOperation mul
 
 evaluateBinaryOperation Divide = evaluateArithmeticBinaryOperation div
 
-evaluateBinaryOperation Power = evaluateArithmeticBinaryOperation pow
+evaluateBinaryOperation Power = (\_ _ _-> unsupportedOperation "pow")
 
-evaluateArithmeticBinaryOperation :: (Number -> Number -> Number) -> VariableMap Number -> Expression -> Expression -> Expect Number
+evaluateArithmeticBinaryOperation :: (Approx -> Approx -> Approx) -> VariableMap Approx -> Expression -> Expression -> Expect Approx
 evaluateArithmeticBinaryOperation operation variableMap leftExpression rightExpression = case evaluate variableMap leftExpression, evaluate variableMap rightExpression of
   Right leftValue, Right rightValue -> pure $ operation leftValue rightValue
   Left leftError, Left rightError -> multipleErrors $ (show leftError) <> " | " <> (show rightError)
   Left leftError, _ -> throw leftError
   _, Left rightError -> throw rightError
 
-evaluateUnaryOperation :: UnaryOperation -> VariableMap Number -> Expression -> Expect Number
+evaluateUnaryOperation :: UnaryOperation -> VariableMap Approx -> Expression -> Expect Approx
 evaluateUnaryOperation (Neg) = evaluateNegate
 
-evaluateUnaryOperation (Sqrt) = evaluateFunction sqrt
+evaluateUnaryOperation (Sqrt) = (\_ _-> unsupportedOperation "sqrt")
 
-evaluateUnaryOperation (Exp) = evaluateFunction exp
+evaluateUnaryOperation (Exp) = (\_ _-> unsupportedOperation "exp")
 
-evaluateUnaryOperation (Log) = evaluateFunction log
+evaluateUnaryOperation (Log) = (\_ _-> unsupportedOperation "log")
 
-evaluateUnaryOperation (Sine) = evaluateFunction sin
+evaluateUnaryOperation (Sine) = (\_ _-> unsupportedOperation "sin")
 
-evaluateUnaryOperation (Cosine) = evaluateFunction cos
+evaluateUnaryOperation (Cosine) = (\_ _-> unsupportedOperation "cos")
 
-evaluateUnaryOperation (Tan) = evaluateFunction tan
+evaluateUnaryOperation (Tan) = (\_ _-> unsupportedOperation "tan")
 
-evaluateFunction :: (Number -> Number) -> VariableMap Number -> Expression -> Expect Number
+evaluateFunction :: (Approx -> Approx) -> VariableMap Approx -> Expression -> Expect Approx
 evaluateFunction op variableMap expression = case evaluate variableMap expression of
   Left error -> throw error
   Right value -> pure $ op value
 
-evaluateNegate :: VariableMap Number -> Expression -> Expect Number
+evaluateNegate :: VariableMap Approx -> Expression -> Expect Approx
 evaluateNegate variableMap expression = case evaluate variableMap expression of
   Left error -> throw error
   Right value -> pure $ -value

--- a/src/Expression/Evaluator.purs
+++ b/src/Expression/Evaluator.purs
@@ -77,7 +77,7 @@ roughEvaluateNegate variableMap expression = case roughEvaluate variableMap expr
 ----------------------------------------------------
 evaluate :: VariableMap Approx -> Expression -> Expect Approx
 evaluate variableMap = case _ of
-  ExpressionLiteral value -> pure $ fromRationalPrec 4 value
+  ExpressionLiteral value -> pure $ fromRationalPrec 50 value
   ExpressionVariable name -> case lookup variableMap name of
     Just value -> pure value
     _ -> unknownValue name

--- a/src/Expression/SubExpression.purs
+++ b/src/Expression/SubExpression.purs
@@ -19,7 +19,7 @@ removeSubExpressions = removeSubExpressionsWithMap []
     ExpressionVariable name -> case VM.lookup variableMap name of
       Just value -> value
       _ -> ExpressionVariable name
-    ExpressionLet name expression parentExpression -> removeSubExpressionsWithMap (variableMap <> [ (Tuple name (removeSubExpressionsWithMap variableMap expression)) ]) parentExpression
+    ExpressionLet name nameExpression parentExpression -> removeSubExpressionsWithMap (variableMap <> [ (Tuple name (removeSubExpressionsWithMap variableMap nameExpression)) ]) parentExpression
     ExpressionUnary op expression -> ExpressionUnary op (removeSubExpressionsWithMap variableMap expression)
     ExpressionBinary op leftExpression rightExpression -> ExpressionBinary op (removeSubExpressionsWithMap variableMap leftExpression) (removeSubExpressionsWithMap variableMap rightExpression)
     expression -> expression

--- a/src/Expression/SubExpression.purs
+++ b/src/Expression/SubExpression.purs
@@ -1,7 +1,6 @@
 module Expression.SubExpression where
 
 import Prelude
-
 import Data.Array (elem, foldr, fromFoldable, null, unsnoc)
 import Data.Map (Map, filterKeys, lookup, toUnfoldable, values)
 import Data.Maybe (Maybe(..))
@@ -18,10 +17,10 @@ removeSubExpressions = removeSubExpressionsWithMap []
   removeSubExpressionsWithMap :: (VM.VariableMap Expression) -> Expression -> Expression
   removeSubExpressionsWithMap variableMap = case _ of
     ExpressionVariable name -> case VM.lookup variableMap name of
-      Just value -> removeSubExpressionsWithMap variableMap value
+      Just value -> value
       _ -> ExpressionVariable name
-    ExpressionLet name expression parentExpression -> removeSubExpressionsWithMap (variableMap <> [ (Tuple name expression) ]) parentExpression
-    ExpressionUnary op expression -> ExpressionUnary op (removeSubExpressionsWithMap variableMap expression) 
+    ExpressionLet name expression parentExpression -> removeSubExpressionsWithMap (variableMap <> [ (Tuple name (removeSubExpressionsWithMap variableMap expression)) ]) parentExpression
+    ExpressionUnary op expression -> ExpressionUnary op (removeSubExpressionsWithMap variableMap expression)
     ExpressionBinary op leftExpression rightExpression -> ExpressionBinary op (removeSubExpressionsWithMap variableMap leftExpression) (removeSubExpressionsWithMap variableMap rightExpression)
     expression -> expression
 

--- a/src/Expression/SubExpression.purs
+++ b/src/Expression/SubExpression.purs
@@ -18,9 +18,11 @@ removeSubExpressions = removeSubExpressionsWithMap []
   removeSubExpressionsWithMap :: (VM.VariableMap Expression) -> Expression -> Expression
   removeSubExpressionsWithMap variableMap = case _ of
     ExpressionVariable name -> case VM.lookup variableMap name of
-      Just value -> value
+      Just value -> removeSubExpressionsWithMap variableMap value
       _ -> ExpressionVariable name
     ExpressionLet name expression parentExpression -> removeSubExpressionsWithMap (variableMap <> [ (Tuple name expression) ]) parentExpression
+    ExpressionUnary op expression -> ExpressionUnary op (removeSubExpressionsWithMap variableMap expression) 
+    ExpressionBinary op leftExpression rightExpression -> ExpressionBinary op (removeSubExpressionsWithMap variableMap leftExpression) (removeSubExpressionsWithMap variableMap rightExpression)
     expression -> expression
 
 joinCommonSubExpressions :: Expression -> Expression

--- a/src/Plot/Commands.purs
+++ b/src/Plot/Commands.purs
@@ -4,15 +4,15 @@ import Expression.Syntax (Expression)
 import Types (XYBounds)
 
 data PlotCommand
-  = Plot XYBounds Expression String
+  = RoughPlot XYBounds Expression String
   | Empty XYBounds
 
 plotExpression :: XYBounds -> Expression -> String -> PlotCommand
-plotExpression = Plot 
+plotExpression = RoughPlot 
 
 clear :: XYBounds -> PlotCommand
 clear = Empty
 
 isPlotExpression :: PlotCommand -> Boolean
-isPlotExpression (Plot _ _ _) = true
+isPlotExpression (RoughPlot _ _ _) = true
 isPlotExpression (Empty _) = false

--- a/src/Plot/Helper.purs
+++ b/src/Plot/Helper.purs
@@ -1,0 +1,24 @@
+module Plot.Helper where
+
+import Prelude
+import Data.Array (length, tail, zipWith, (!!))
+import Data.Maybe (fromMaybe)
+import Data.Traversable (for_)
+import Draw.Actions (drawPlotLine, drawText)
+import Draw.Color (rgba)
+import Draw.Commands (DrawCommand)
+import Types (Position)
+
+drawLabel :: String -> Array Position -> Int -> Int -> DrawCommand Unit
+drawLabel label points numberOfPlots index = drawText color ("f(x)=" <> label) 20.0 labelPosition
+  where
+  pointIndex = (length points) / (numberOfPlots + 1)
+
+  color = rgba 255.0 0.0 0.0 1.0
+
+  labelPosition = fromMaybe { x: 0.0, y: 0.0 } $ points !! (pointIndex * index)
+
+drawPlot :: Array Position -> DrawCommand Unit
+drawPlot points = for_ lines (\l -> drawPlotLine l.a l.b)
+  where
+  lines = zipWith (\a b -> { a, b }) points (fromMaybe [] (tail points))

--- a/src/Plot/PlotController.purs
+++ b/src/Plot/PlotController.purs
@@ -2,7 +2,7 @@ module Plot.PlotController where
 
 import Prelude
 
-import Data.Array (concat, fold, length, tail, zipWith, (!!), (..), mapWithIndex, filter)
+import Data.Array (concat, fold, length, mapWithIndex, tail, zipWith, (!!), (..))
 import Data.Either (Either(..))
 import Data.Int (floor, toNumber)
 import Data.Maybe (Maybe(..), fromMaybe)
@@ -49,18 +49,15 @@ evaluateWithX expression x = value
 runCommand :: Size -> Int -> Int -> PlotCommand -> DrawCommand Unit
 runCommand _ _ _ (Empty bounds) = clearAndDrawGridLines bounds
 
-runCommand canvasSize numberOfPlots index (Plot bounds expression label) = drawCommands
+runCommand canvasSize numberOfPlots index (RoughPlot bounds expression label) = drawCommands
   where
   f = evaluateWithX expression
 
   f'' = evaluateWithX $ simplify $ secondDifferentiate expression
 
-  points = filter (isWithinCanvas canvasSize) $ plotPoints canvasSize bounds f f''
+  points = plotPoints canvasSize bounds f f''
 
   drawCommands = fold [ drawPlot points, drawLabel label points numberOfPlots index ]
-
-isWithinCanvas :: Size -> Position -> Boolean
-isWithinCanvas canvasSize point = point.x >= 0.0 && point.x <= canvasSize.width + 1.0 && point.y >= 0.0 && point.y <= canvasSize.height + 1.0
 
 drawLabel :: String -> Array Position -> Int -> Int -> DrawCommand Unit
 drawLabel label points numberOfPlots index = drawText color ("f(x)=" <> label) 20.0 labelPosition

--- a/src/Plot/PlotController.purs
+++ b/src/Plot/PlotController.purs
@@ -2,25 +2,17 @@ module Plot.PlotController where
 
 import Prelude
 
-import Data.Array (concat, fold, length, mapWithIndex, tail, zipWith, (!!), (..))
+import Data.Array (fold, mapWithIndex)
 import Data.Either (Either(..))
-import Data.Int (floor, toNumber)
-import Data.Maybe (Maybe(..), fromMaybe)
-import Data.Traversable (for_, sum)
-import Data.Tuple (Tuple(..))
-import Draw.Actions (drawPlotLine, drawText)
-import Draw.Color (rgba)
+import Data.Enum (fromEnum)
+import Data.Traversable (sum)
 import Draw.Commands (DrawCommand)
 import Effect (Effect)
 import Effect.Aff (Aff, Canceler, Error, makeAff, nonCanceler)
-import Expression.Differentiator (secondDifferentiate)
-import Expression.Evaluator (roughEvaluate, presetConstants)
-import Expression.Simplifier (simplify)
-import Expression.Syntax (Expression)
-import Math (abs)
 import Plot.Commands (PlotCommand(..), isPlotExpression)
 import Plot.GridLines (clearAndDrawGridLines)
-import Types (Size, XYBounds, Position)
+import Plot.RoughPlot (drawRoughPlot)
+import Types (Size)
 
 computePlotAsync :: Size -> Array PlotCommand -> Aff (DrawCommand Unit)
 computePlotAsync canvasSize plot = makeAff $ runComputation canvasSize plot
@@ -35,82 +27,9 @@ runComputation canvasSize commands callback = do
   result = fold $ mapWithIndex (runCommand canvasSize numberOfPlots) commands
 
 countPlots :: Array PlotCommand -> Int
-countPlots commands = sum $ map (isPlotExpression >>> (\isPlot -> if isPlot then 1 else 0)) commands
-
-evaluateWithX :: Expression -> Number -> Number
-evaluateWithX expression x = value
-  where
-  variableMap = presetConstants <> [ Tuple "x" x ]
-
-  value = case roughEvaluate variableMap expression of
-    Left _ -> 0.0
-    Right v -> v
+countPlots = sum <<< map (fromEnum <<< isPlotExpression)
 
 runCommand :: Size -> Int -> Int -> PlotCommand -> DrawCommand Unit
 runCommand _ _ _ (Empty bounds) = clearAndDrawGridLines bounds
 
-runCommand canvasSize numberOfPlots index (RoughPlot bounds expression label) = drawCommands
-  where
-  f = evaluateWithX expression
-
-  f'' = evaluateWithX $ simplify $ secondDifferentiate expression
-
-  points = plotPoints canvasSize bounds f f''
-
-  drawCommands = fold [ drawPlot points, drawLabel label points numberOfPlots index ]
-
-drawLabel :: String -> Array Position -> Int -> Int -> DrawCommand Unit
-drawLabel label points numberOfPlots index = drawText color ("f(x)=" <> label) 20.0 labelPosition
-  where
-  pointIndex = (length points) / (numberOfPlots + 1)
-
-  color = rgba 255.0 0.0 0.0 1.0
-
-  labelPosition = fromMaybe { x: 0.0, y: 0.0 } $ points !! (pointIndex * index)
-
-plotPoints :: Size -> XYBounds -> (Number -> Number) -> (Number -> Number) -> Array Position
-plotPoints canvasSize bounds f f'' = points
-  where
-  rangeX = bounds.xBounds.upper - bounds.xBounds.lower
-
-  rangeY = bounds.yBounds.upper - bounds.yBounds.lower
-
-  defaultRange = map (toNumber >>> toDomainX) $ 0 .. (floor canvasSize.width)
-
-  changeInGradient = map f'' defaultRange
-
-  points = map toCanvasPoint $ concat $ zipWith toRange changeInGradient defaultRange
-
-  toRange :: Number -> Number -> Array Number
-  toRange deltaGradient value =
-    if (abs deltaGradient) < (canvasSize.width / rangeX) then
-      [ value ]
-    else
-      map (toSubRange <<< toNumber) $ -5 .. 5
-    where
-    toSubRange :: Number -> Number
-    toSubRange x = value + ((x * rangeX) / (canvasSize.width * 10.0))
-
-  toCanvasX :: Number -> Number
-  toCanvasX x = ((x - bounds.xBounds.lower) * canvasSize.width) / rangeX
-
-  toCanvasY :: Number -> Number
-  toCanvasY y = canvasSize.height - (((y - bounds.yBounds.lower) * canvasSize.height) / rangeY)
-
-  toDomainX :: Number -> Number
-  toDomainX canvasX = ((canvasX * rangeX) / canvasSize.width) + bounds.xBounds.lower
-
-  toCanvasPoint :: Number -> Position
-  toCanvasPoint x = { x: toCanvasX x, y: toCanvasY y }
-    where
-    y = f x
-
-drawPlot :: Array Position -> DrawCommand Unit
-drawPlot points = for_ lines (\l -> drawPlotLine l.a l.b)
-  where
-  lines = zipWith (\a b -> { a, b }) points (fromMaybe [] (tail points))
-
-toMaybePlotCommand :: PlotCommand -> Maybe PlotCommand
-toMaybePlotCommand (Empty _) = Nothing
-
-toMaybePlotCommand p = Just p
+runCommand canvasSize numberOfPlots index (RoughPlot bounds expression label) = drawRoughPlot canvasSize numberOfPlots index bounds expression label

--- a/src/Plot/PlotController.purs
+++ b/src/Plot/PlotController.purs
@@ -14,7 +14,7 @@ import Draw.Commands (DrawCommand)
 import Effect (Effect)
 import Effect.Aff (Aff, Canceler, Error, makeAff, nonCanceler)
 import Expression.Differentiator (secondDifferentiate)
-import Expression.Evaluator (evaluate, presetConstants)
+import Expression.Evaluator (roughEvaluate, presetConstants)
 import Expression.Simplifier (simplify)
 import Expression.Syntax (Expression)
 import Math (abs)
@@ -42,7 +42,7 @@ evaluateWithX expression x = value
   where
   variableMap = presetConstants <> [ Tuple "x" x ]
 
-  value = case evaluate variableMap expression of
+  value = case roughEvaluate variableMap expression of
     Left _ -> 0.0
     Right v -> v
 

--- a/src/Plot/RoughPlot.purs
+++ b/src/Plot/RoughPlot.purs
@@ -1,0 +1,72 @@
+module Plot.RoughPlot where
+
+import Prelude
+import Data.Array (concat, fold, zipWith, (..))
+import Data.Either (Either(..))
+import Data.Int (floor, toNumber)
+import Data.Tuple (Tuple(..))
+import Draw.Commands (DrawCommand)
+import Expression.Differentiator (secondDifferentiate)
+import Expression.Evaluator (roughEvaluate, presetConstants)
+import Expression.Simplifier (simplify)
+import Expression.Syntax (Expression)
+import Math (abs)
+import Plot.Helper (drawLabel, drawPlot)
+import Types (Size, XYBounds, Position)
+
+drawRoughPlot :: Size -> Int -> Int -> XYBounds -> Expression -> String -> DrawCommand Unit
+drawRoughPlot canvasSize numberOfPlots index bounds expression label = drawCommands
+  where
+  f = evaluateWithX expression
+
+  f'' = (evaluateWithX <<< simplify <<< secondDifferentiate) expression
+
+  points = plotPoints canvasSize bounds f f''
+
+  drawCommands = fold [ drawPlot points, drawLabel label points numberOfPlots index ]
+
+evaluateWithX :: Expression -> Number -> Number
+evaluateWithX expression x = value
+  where
+  variableMap = presetConstants <> [ Tuple "x" x ]
+
+  value = case roughEvaluate variableMap expression of
+    Left _ -> 0.0
+    Right v -> v
+
+plotPoints :: Size -> XYBounds -> (Number -> Number) -> (Number -> Number) -> Array Position
+plotPoints canvasSize bounds f f'' = points
+  where
+  rangeX = bounds.xBounds.upper - bounds.xBounds.lower
+
+  rangeY = bounds.yBounds.upper - bounds.yBounds.lower
+
+  defaultRange = map (toNumber >>> toDomainX) $ 0 .. (floor canvasSize.width)
+
+  changeInGradient = map f'' defaultRange
+
+  points = map toCanvasPoint $ concat $ zipWith toRange changeInGradient defaultRange
+
+  toRange :: Number -> Number -> Array Number
+  toRange deltaGradient value =
+    if (abs deltaGradient) < (canvasSize.width / rangeX) then
+      [ value ]
+    else
+      map (toSubRange <<< toNumber) $ -5 .. 5
+    where
+    toSubRange :: Number -> Number
+    toSubRange x = value + ((x * rangeX) / (canvasSize.width * 10.0))
+
+  toCanvasX :: Number -> Number
+  toCanvasX x = ((x - bounds.xBounds.lower) * canvasSize.width) / rangeX
+
+  toCanvasY :: Number -> Number
+  toCanvasY y = canvasSize.height - (((y - bounds.yBounds.lower) * canvasSize.height) / rangeY)
+
+  toDomainX :: Number -> Number
+  toDomainX canvasX = ((canvasX * rangeX) / canvasSize.width) + bounds.xBounds.lower
+
+  toCanvasPoint :: Number -> Position
+  toCanvasPoint x = { x: toCanvasX x, y: toCanvasY y }
+    where
+    y = f x

--- a/test/Expression/Evaluator/Evaluate.purs
+++ b/test/Expression/Evaluator/Evaluate.purs
@@ -1,0 +1,378 @@
+module Test.Expression.Evaluator.Evaluate
+  ( evaluateTests
+  ) where
+
+import Prelude
+import Data.Either (Either(..))
+import Data.Ratio ((%))
+import Data.Tuple (Tuple(..))
+import Expression.Error (Expect, throw)
+import Expression.Evaluator (evaluate)
+import Expression.Parser (parse)
+import Expression.VariableMap (VariableMap)
+import IntervalArith.Approx (Approx, consistent, fromRationalPrec)
+import IntervalArith.Misc (big)
+import Test.Expression.Helper (expectValue)
+import Test.Unit (TestSuite, suite, test)
+import Test.Unit.Assert (equal)
+
+evaluateTests :: TestSuite
+evaluateTests =
+  suite "Expression.Evaluator - evaluate" do
+    test "ASSERT f(x) = 9.0 WHEN f(x) = 4+5" do
+      let
+        -- given
+        rawExpression = "4+5"
+
+        -- when
+        result = parseAndEvaluate [] rawExpression
+
+        -- then
+        expectedResult = ratioHelp 9 1
+      expectValue result
+        $ \value ->
+            equal true $ consistent value expectedResult
+    test "ASSERT f(x) = 7.5 WHEN f(x) = 4.5+3" do
+      let
+        -- given
+        rawExpression = "4.5+3"
+
+        -- when
+        result = parseAndEvaluate [] rawExpression
+
+        -- then
+        expectedResult = ratioHelp 15 2
+      expectValue result
+        $ \value ->
+            equal true $ consistent value expectedResult
+    test "ASSERT f(x) = 12.0 WHEN f(x) = 4*3" do
+      let
+        -- given
+        rawExpression = "4*3"
+
+        -- when
+        result = parseAndEvaluate [] rawExpression
+
+        -- then
+        expectedResult = ratioHelp 12 1
+      expectValue result
+        $ \value ->
+            equal true $ consistent value expectedResult
+    test "ASSERT f(x) = 9.0 WHEN f(x) = 4.5*2" do
+      let
+        -- given
+        rawExpression = "4.5*2"
+
+        -- when
+        result = parseAndEvaluate [] rawExpression
+
+        -- then
+        expectedResult = ratioHelp 9 1
+      expectValue result
+        $ \value ->
+            equal true $ consistent value expectedResult
+    test "ASSERT f(x) = 4.0 WHEN f(x) = 8/2" do
+      let
+        -- given
+        rawExpression = "8/2"
+
+        -- when
+        result = parseAndEvaluate [] rawExpression
+
+        -- then
+        expectedResult = ratioHelp 4 1
+      expectValue result
+        $ \value ->
+            equal true $ consistent value expectedResult
+    test "ASSERT f(x) = 4.5 WHEN f(x) = 9/2" do
+      let
+        -- given
+        rawExpression = "9/2"
+
+        -- when
+        result = parseAndEvaluate [] rawExpression
+
+        -- then
+        expectedResult = ratioHelp 9 2
+      expectValue result
+        $ \value ->
+            equal true $ consistent value expectedResult
+    test "ASSERT f(x) = 4.75 WHEN f(x) = 9.5/2" do
+      let
+        -- given
+        rawExpression = "9.5/2"
+
+        -- when
+        result = parseAndEvaluate [] rawExpression
+
+        -- then
+        expectedResult = ratioHelp 19 4
+      expectValue result
+        $ \value ->
+            equal true $ consistent value expectedResult
+    test "ASSERT f(x) = 4.75 WHEN f(x) = 9.5/2" do
+      let
+        -- given
+        rawExpression = "9.5/2"
+
+        -- when
+        result = parseAndEvaluate [] rawExpression
+
+        -- then
+        expectedResult = ratioHelp 19 4
+      expectValue result
+        $ \value ->
+            equal true $ consistent value expectedResult
+    test "ASSERT f(x) = 7.0 WHEN f(x) = 9-2" do
+      let
+        -- given
+        rawExpression = "9-2"
+
+        -- when
+        result = parseAndEvaluate [] rawExpression
+
+        -- then
+        expectedResult = ratioHelp 7 1
+      expectValue result
+        $ \value ->
+            equal true $ consistent value expectedResult
+    test "ASSERT f(x) = 6.0 WHEN f(x) = 9.5-3.5" do
+      let
+        -- given
+        rawExpression = "9.5-3.5"
+
+        -- when
+        result = parseAndEvaluate [] rawExpression
+
+        -- then
+        expectedResult = ratioHelp 6 1
+      expectValue result
+        $ \value ->
+            equal true $ consistent value expectedResult
+    test "ASSERT f(x) = 12.0 WHEN f(x) = (2+4)+6" do
+      let
+        -- given
+        rawExpression = "(2+4)+6"
+
+        -- when
+        result = parseAndEvaluate [] rawExpression
+
+        -- then
+        expectedResult = ratioHelp 12 1
+      expectValue result
+        $ \value ->
+            equal true $ consistent value expectedResult
+    test "ASSERT f(x) = 36.0 WHEN f(x) = (2+4)*6" do
+      let
+        -- given
+        rawExpression = "(2+4)*6"
+
+        -- when
+        result = parseAndEvaluate [] rawExpression
+
+        -- then
+        expectedResult = ratioHelp 36 1
+      expectValue result
+        $ \value ->
+            equal true $ consistent value expectedResult
+    test "ASSERT f(x) = 26.0 WHEN f(x) = 2+4*6" do
+      let
+        -- given
+        rawExpression = "2+4*6"
+
+        -- when
+        result = parseAndEvaluate [] rawExpression
+
+        expectedResult = ratioHelp 26 1
+      -- then
+      expectValue result
+        $ \value ->
+            equal true $ consistent value expectedResult
+    test "SHOULD throw error 'Unsupported operation: pow' WHEN f(x) = 2^3" do
+      let
+        -- given
+        rawExpression = "2^3"
+
+        -- when
+        result = fromExpect $ parseAndEvaluate [] rawExpression
+
+        -- then
+        expectedResult = "Unsupported operation: pow"
+      equal expectedResult result
+    test "SHOULD throw error 'Unsupported operation: sin' WHEN f(x) = sin(pi/2)" do
+      let
+        -- given
+        rawExpression = "sin(pi/2)"
+
+        -- when
+        result = fromExpect $ parseAndEvaluate [] rawExpression
+
+        -- then
+        expectedResult = "Unsupported operation: sin"
+      equal expectedResult result
+    test "SHOULD throw error 'Unsupported operation: cos' WHEN f(x) = cos(pi)" do
+      let
+        -- given
+        rawExpression = "cos(pi)"
+
+        -- when
+        result = fromExpect $ parseAndEvaluate [] rawExpression
+
+        -- then
+        expectedResult = "Unsupported operation: cos"
+      equal expectedResult result
+    test "SHOULD throw error 'Unsupported operation: cos' WHEN f(x) = cos(0)" do
+      let
+        -- given
+        rawExpression = "cos(0)"
+
+        -- when
+        result = fromExpect $ parseAndEvaluate [] rawExpression
+
+        -- then
+        expectedResult = "Unsupported operation: cos"
+      equal expectedResult result
+    test "SHOULD throw error 'Unsupported operation: tan' WHEN f(x) = tan(0)" do
+      let
+        -- given
+        rawExpression = "tan(0)"
+
+        -- when
+        result = fromExpect $ parseAndEvaluate [] rawExpression
+
+        -- then
+        expectedResult = "Unsupported operation: tan"
+      equal expectedResult result
+    test "SHOULD throw error 'Unsupported operation: sqrt' WHEN f(x) = sqrt(4)" do
+      let
+        -- given
+        rawExpression = "sqrt(4)"
+
+        -- when
+        result = fromExpect $ parseAndEvaluate [] rawExpression
+
+        -- then
+        expectedResult = "Unsupported operation: sqrt"
+      equal expectedResult result
+    test "SHOULD throw error 'Unsupported operation: log' WHEN f(x) = log(1)" do
+      let
+        -- given
+        rawExpression = "log(1)"
+
+        -- when
+        result = fromExpect $ parseAndEvaluate [] rawExpression
+
+        -- then
+        expectedResult = "Unsupported operation: log"
+      equal expectedResult result
+    test "ASSERT f(x) = 5.0 WHEN f(x) = x AND x = 5.0" do
+      let
+        -- given
+        x = 5.0
+
+        variables = [ (Tuple "x" (ratioHelp 5 1)) ]
+
+        rawExpression = "x"
+
+        -- when
+        result = parseAndEvaluate variables rawExpression
+
+        -- then
+        expectedResult = ratioHelp 5 1
+      expectValue result
+        $ \value ->
+            equal true $ consistent value expectedResult
+    test "ASSERT f(x) = 4.0 WHEN f(x) = 2.0*x AND x = 2.0" do
+      let
+        -- given
+        x = 2.0
+
+        variables = [ (Tuple "x" (ratioHelp 2 1)) ]
+
+        rawExpression = "2.0*x"
+
+        -- when
+        result = parseAndEvaluate variables rawExpression
+
+        -- then
+        expectedResult = ratioHelp 4 1
+      expectValue result
+        $ \value ->
+            equal true $ consistent value expectedResult
+    test "ASSERT f(x) = 4.0 WHEN f(x) = 2*x AND x = 2.0" do
+      let
+        -- given
+        x = 2.0
+
+        variables = [ (Tuple "x" (ratioHelp 2 1)) ]
+
+        rawExpression = "2.0*x"
+
+        -- when
+        result = parseAndEvaluate variables rawExpression
+
+        -- then
+        expectedResult = ratioHelp 4 1
+      expectValue result
+        $ \value ->
+            equal true $ consistent value expectedResult
+    test "SHOULD throw error 'Unsupported operation: pow' WHEN f(x) = 1 / (1 + (100 * (x ^ 2))) AND x = 0.0" do
+      let
+        -- given
+        x = 0.0
+
+        variables = [ (Tuple "x" (ratioHelp 0 1)) ]
+
+        rawExpression = "1 / (1 + (100 * (x ^ 2)))"
+
+        -- when
+        result = fromExpect $ parseAndEvaluate variables rawExpression
+
+        -- then
+        expectedResult = "Unsupported operation: pow"
+      equal expectedResult result
+    test "SHOULD throw error 'Unsupported operation: pow' WHEN f(x) = 1 / (1 + (100 * (x ^ 2))) AND x = 0.1" do
+      let
+        -- given
+        x = 0.1
+
+        variables = [ (Tuple "x" (ratioHelp 1 10)) ]
+
+        rawExpression = "1 / (1 + (100 * (x ^ 2)))"
+
+        -- when
+        result = fromExpect $ parseAndEvaluate variables rawExpression
+
+        -- then
+        expectedResult = "Unsupported operation: pow"
+      equal expectedResult result
+    test "SHOULD throw error 'Unknown value: a | Unknown value: b' WHEN f(x) = a + b AND a is undefined AND b in undefined" do
+      let
+        -- given
+        rawExpression = "a + b"
+
+        -- when
+        result = fromExpect $ parseAndEvaluate [] rawExpression
+
+        -- then
+        expectedResult = "Unknown value: a | Unknown value: b"
+      equal expectedResult result
+
+parseAndEvaluate :: VariableMap Approx -> String -> Expect Approx
+parseAndEvaluate variableMap rawExpression = result
+  where
+  expressionOrParseError = parse rawExpression
+
+  valueOrEvaluationError = case expressionOrParseError of
+    Right expression -> evaluate variableMap expression
+    Left error -> throw error
+
+  result = valueOrEvaluationError
+
+ratioHelp :: Int -> Int -> Approx
+ratioHelp n d = fromRationalPrec 50 ((big n) % (big d))
+
+fromExpect :: Expect Approx -> String
+fromExpect (Right value) = show value
+
+fromExpect (Left error) = show error

--- a/test/Expression/Evaluator/Evaluator.purs
+++ b/test/Expression/Evaluator/Evaluator.purs
@@ -2,9 +2,12 @@ module Test.Expression.Evaluator
   ( evaluatorTests
   ) where
 
+import Prelude
 import Test.Unit (TestSuite)
 import Test.Expression.Evaluator.RoughEvaluate (roughEvaluateTests)
+import Test.Expression.Evaluator.Evaluate (evaluateTests)
 
 evaluatorTests :: TestSuite
 evaluatorTests = do
   roughEvaluateTests
+  evaluateTests

--- a/test/Expression/Evaluator/Evaluator.purs
+++ b/test/Expression/Evaluator/Evaluator.purs
@@ -3,8 +3,8 @@ module Test.Expression.Evaluator
   ) where
 
 import Test.Unit (TestSuite)
-import Test.Expression.Evaluator.Evaluate (evaluateTests)
+import Test.Expression.Evaluator.RoughEvaluate (roughEvaluateTests)
 
 evaluatorTests :: TestSuite
 evaluatorTests = do
-  evaluateTests
+  roughEvaluateTests

--- a/test/Expression/Evaluator/RoughEvaluate.purs
+++ b/test/Expression/Evaluator/RoughEvaluate.purs
@@ -1,5 +1,5 @@
-module Test.Expression.Evaluator.Evaluate
-  ( evaluateTests
+module Test.Expression.Evaluator.RoughEvaluate
+  ( roughEvaluateTests
   ) where
 
 import Prelude
@@ -8,16 +8,16 @@ import Data.Int (toNumber)
 import Data.Tuple (Tuple(..))
 import Expression.Error (Expect, throw)
 import Expression.VariableMap (VariableMap)
-import Expression.Evaluator (evaluate, presetConstants)
+import Expression.Evaluator (roughEvaluate, presetConstants)
 import Expression.Parser (parse)
 import Test.QuickCheck ((===))
 import Test.Unit (TestSuite, suite, test)
 import Test.Unit.Assert (equal)
 import Test.Unit.QuickCheck (quickCheck)
 
-evaluateTests :: TestSuite
-evaluateTests =
-  suite "Expression.Evaluator - evaluate" do
+roughEvaluateTests :: TestSuite
+roughEvaluateTests =
+  suite "Expression.Evaluator - roughEvaluate" do
     test "ASSERT f(x) = n WHEN f(x) = n FOR ANY integer n" $ quickCheck
       $ \(n :: Int) -> do
           let
@@ -413,7 +413,7 @@ parseAndEvaluate variables rawExpression = result
   expressionOrParseError = parse rawExpression
 
   valueOrEvaluationError = case expressionOrParseError of
-    Right expression -> evaluate variables expression
+    Right expression -> roughEvaluate variables expression
     Left error -> throw error
 
   result = valueOrEvaluationError

--- a/test/Expression/SubExpression/JoinCommonSubExpressions.purs
+++ b/test/Expression/SubExpression/JoinCommonSubExpressions.purs
@@ -3,14 +3,18 @@ module Test.Expression.SubExpression.JoinCommonSubExpressions
   ) where
 
 import Prelude
-
 import Data.Either (Either(..))
+import Data.Int (toNumber)
+import Data.Tuple (Tuple(..))
 import Expression.Error (Expect, throw)
+import Expression.Evaluator (presetConstants, roughEvaluate)
 import Expression.Parser (parse)
 import Expression.SubExpression (joinCommonSubExpressions)
 import Expression.Syntax (Expression)
+import Test.QuickCheck (Result(..), assertEquals)
 import Test.Unit (TestSuite, suite, test)
 import Test.Unit.Assert (equal)
+import Test.Unit.QuickCheck (quickCheck)
 
 joinCommonSubExpressionsTests :: TestSuite
 joinCommonSubExpressionsTests =
@@ -81,6 +85,20 @@ joinCommonSubExpressionsTests =
         -- then
         expectedResult = "let $v2 = x+x in let $v4 = $v2+$v2 in let $v1 = sin$v4 in let $v3 = $v1+$v2 in $v3+$v1"
       equal expectedResult result
+    test "ASSERT yeilds the same result WHEN f(x) = sin((x+x)+(x+x))+(x+x)+sin((x+x)+(x+x)) WHERE x = n FOR ANY integer n" $ quickCheck
+      $ \(n :: Int) -> do
+          let
+            -- given
+            variables = presetConstants <> [ Tuple "x" (toNumber n) ]
+
+            rawExpression = "sin((x+x)+(x+x))+(x+x)+sin((x+x)+(x+x))"
+          case parse rawExpression of
+            Left error -> Failed $ show error
+            Right expression -> case roughEvaluate variables (joinCommonSubExpressions expression), roughEvaluate variables expression of
+              Right joinedValue, Right value -> assertEquals joinedValue value
+              Right _, Left error -> Failed $ show error
+              Left error, Right _ -> Failed $ show error
+              Left _, Left _ -> Failed "Failed to evaluate expression"
 
 parseAndJoinCommonSubExpressions :: String -> Expect Expression
 parseAndJoinCommonSubExpressions rawExpression = result
@@ -90,7 +108,7 @@ parseAndJoinCommonSubExpressions rawExpression = result
   result = case expressionOrParseError of
     Right expression -> pure $ joinCommonSubExpressions expression
     Left error -> throw error
-  
+
 fromExpect :: Expect Expression -> String
 fromExpect (Right expression) = show expression
 

--- a/test/Expression/SubExpression/JoinCommonSubExpressions.purs
+++ b/test/Expression/SubExpression/JoinCommonSubExpressions.purs
@@ -3,9 +3,11 @@ module Test.Expression.SubExpression.JoinCommonSubExpressions
   ) where
 
 import Prelude
+
 import Data.Either (Either(..))
 import Data.Int (toNumber)
 import Data.Tuple (Tuple(..))
+import Expression.Differentiator (differentiate)
 import Expression.Error (Expect, throw)
 import Expression.Evaluator (presetConstants, roughEvaluate)
 import Expression.Parser (parse)
@@ -95,6 +97,20 @@ joinCommonSubExpressionsTests =
           case parse rawExpression of
             Left error -> Failed $ show error
             Right expression -> case roughEvaluate variables (joinCommonSubExpressions expression), roughEvaluate variables expression of
+              Right joinedValue, Right value -> assertEquals joinedValue value
+              Right _, Left error -> Failed $ show error
+              Left error, Right _ -> Failed $ show error
+              Left _, Left _ -> Failed "Failed to evaluate expression"
+    test "ASSERT yeilds the same result WHEN f(x) = sin((x+x)+(x+x))+(x+x)+sin((x+x)+(x+x)) WHERE is differentiated AND x = n FOR ANY integer n" $ quickCheck
+      $ \(n :: Int) -> do
+          let
+            -- given
+            variables = presetConstants <> [ Tuple "x" (toNumber n) ]
+
+            rawExpression = "sin((x+x)+(x+x))+(x+x)+sin((x+x)+(x+x))"
+          case parse rawExpression of
+            Left error -> Failed $ show error
+            Right expression -> case roughEvaluate variables (differentiate $ joinCommonSubExpressions expression), roughEvaluate variables (differentiate expression) of
               Right joinedValue, Right value -> assertEquals joinedValue value
               Right _, Left error -> Failed $ show error
               Left error, Right _ -> Failed $ show error

--- a/test/Expression/SubExpression/RemoveSubExpressions.purs
+++ b/test/Expression/SubExpression/RemoveSubExpressions.purs
@@ -1,0 +1,54 @@
+module Test.Expression.SubExpression.RemoveSubExpressions
+  ( removeSubExpressionsTests
+  ) where
+
+import Prelude
+import Data.Either (Either(..))
+import Expression.Parser (parse)
+import Expression.SubExpression (joinCommonSubExpressions, removeSubExpressions)
+import Test.Unit (TestSuite, failure, suite, test)
+import Test.Unit.Assert (equal)
+
+removeSubExpressionsTests :: TestSuite
+removeSubExpressionsTests =
+  suite "Expression.SubExpression - removeSubExpressions" do
+    test "SHOULD undo 'joinCommonSubExpressions' WHEN f(x) = sin(sin(sin(x)))+sin(sin(x))+sin(x)" do
+      let
+        -- given
+        rawExpression = "sin(sin(sin(x)))+sin(sin(x))+sin(x)"
+
+        wrapAndUnwrap = removeSubExpressions <<< joinCommonSubExpressions
+      -- when
+      case parse rawExpression of
+        Left error -> failure $ show error
+        Right expression -> equal (show $ wrapAndUnwrap expression) (show expression)
+    test "SHOULD undo 'joinCommonSubExpressions' WHEN f(x) = (x+x)+(x+x)" do
+      let
+        -- given
+        rawExpression = "(x+x)+(x+x)"
+
+        wrapAndUnwrap = removeSubExpressions <<< joinCommonSubExpressions
+      -- when
+      case parse rawExpression of
+        Left error -> failure $ show error
+        Right expression -> equal (show $ wrapAndUnwrap expression) (show expression)
+    test "SHOULD undo 'joinCommonSubExpressions' WHEN f(x) = x+x" do
+      let
+        -- given
+        rawExpression = "x+x"
+
+        wrapAndUnwrap = removeSubExpressions <<< joinCommonSubExpressions
+      -- when
+      case parse rawExpression of
+        Left error -> failure $ show error
+        Right expression -> equal (show $ wrapAndUnwrap expression) (show expression)
+    test "SHOULD undo 'joinCommonSubExpressions' WHEN f(x) = sin((x+x)+(x+x))+(x+x)+sin((x+x)+(x+x))" do
+      let
+        -- given
+        rawExpression = "sin((x+x)+(x+x))+(x+x)+sin((x+x)+(x+x))"
+
+        wrapAndUnwrap = removeSubExpressions <<< joinCommonSubExpressions
+      -- when
+      case parse rawExpression of
+        Left error -> failure $ show error
+        Right expression -> equal (show $ wrapAndUnwrap expression) (show expression)

--- a/test/Expression/SubExpression/RemoveSubExpressions.purs
+++ b/test/Expression/SubExpression/RemoveSubExpressions.purs
@@ -3,9 +3,11 @@ module Test.Expression.SubExpression.RemoveSubExpressions
   ) where
 
 import Prelude
+
 import Data.Either (Either(..))
 import Expression.Parser (parse)
 import Expression.SubExpression (joinCommonSubExpressions, removeSubExpressions)
+import Expression.Syntax (Expression)
 import Test.Unit (TestSuite, failure, suite, test)
 import Test.Unit.Assert (equal)
 
@@ -16,8 +18,6 @@ removeSubExpressionsTests =
       let
         -- given
         rawExpression = "sin(sin(sin(x)))+sin(sin(x))+sin(x)"
-
-        wrapAndUnwrap = removeSubExpressions <<< joinCommonSubExpressions
       -- when
       case parse rawExpression of
         Left error -> failure $ show error
@@ -26,8 +26,6 @@ removeSubExpressionsTests =
       let
         -- given
         rawExpression = "(x+x)+(x+x)"
-
-        wrapAndUnwrap = removeSubExpressions <<< joinCommonSubExpressions
       -- when
       case parse rawExpression of
         Left error -> failure $ show error
@@ -36,8 +34,6 @@ removeSubExpressionsTests =
       let
         -- given
         rawExpression = "x+x"
-
-        wrapAndUnwrap = removeSubExpressions <<< joinCommonSubExpressions
       -- when
       case parse rawExpression of
         Left error -> failure $ show error
@@ -46,9 +42,10 @@ removeSubExpressionsTests =
       let
         -- given
         rawExpression = "sin((x+x)+(x+x))+(x+x)+sin((x+x)+(x+x))"
-
-        wrapAndUnwrap = removeSubExpressions <<< joinCommonSubExpressions
       -- when
       case parse rawExpression of
         Left error -> failure $ show error
         Right expression -> equal (show $ wrapAndUnwrap expression) (show expression)
+
+wrapAndUnwrap :: Expression -> Expression
+wrapAndUnwrap = removeSubExpressions <<< joinCommonSubExpressions

--- a/test/Expression/SubExpression/SubExpression.purs
+++ b/test/Expression/SubExpression/SubExpression.purs
@@ -9,6 +9,7 @@ import Test.Expression.SubExpression.SplitSubExpressions (splitSubExpressionsTes
 import Test.Expression.SubExpression.SubExpressionToVariableMap (subExpressionToVariableMapTests)
 import Test.Expression.SubExpression.SubstituteSubExpressions (substituteSubExpressionsTests)
 import Test.Expression.SubExpression.OrderDepencencies (orderDepencenciesTests)
+import Test.Expression.SubExpression.RemoveSubExpressions (removeSubExpressionsTests)
 
 subExpressionTests :: TestSuite
 subExpressionTests = do
@@ -17,3 +18,5 @@ subExpressionTests = do
   substituteSubExpressionsTests
   orderDepencenciesTests
   joinCommonSubExpressionsTests
+  removeSubExpressionsTests
+  


### PR DESCRIPTION
# Issues
closes #49 
fixes #55 
fixes #4  

# Summary of changes
- Updated the CI pipeline to actually run the tests (this required small changes to `package.json`)
- Refactored `Expression.Differentiator` to use `zero` and `one` from `Semiring` instead of building a rational from the number value.
- Added `UnsupportedOperation` to `Error` type for the `Approx` functions that are not currently supported
- Renamed `evaluate` function that yields a `Number` to `roughEvaluate` 
- Added `evaluate` function that yields an `Approx`
- Fixed bug in `removeSubExpressions` which subexpressions were not removed from the parent expression

# Tests
- Test.Expression.Evaluator.Evaluate (Added)
- Test.Expression.Evaluator.RoughEvaluate (Added)
- Test.Expression.SubExpression.JoinCommonSubExpressions (Updated)
- Test.Expression.SubExpression.RemoveSubExpressions (Added)
