### PR TITLE
Added Batch and Segment input

### DIFF
--- a/src/Components/BatchInput/BatchInput.purs
+++ b/src/Components/BatchInput/BatchInput.purs
@@ -1,0 +1,111 @@
+module Components.BatchInput where
+
+import Prelude
+import Data.Either (Either(..))
+import Data.Int (fromString)
+import Data.Maybe (Maybe(..))
+import Data.Tuple (Tuple(..))
+import Effect.Class (class MonadEffect)
+import Halogen as H
+import Halogen.HTML as HH
+import Halogen.HTML.Events as HE
+import Halogen.HTML.Properties as HP
+
+type BatchInputSlot p
+  = forall q. H.Slot q BatchInputMessage p
+
+type State
+  = { batchCount :: String
+    , segmentCount :: String
+    }
+
+data BatchInputMessage
+  = UpdatedBatchInput Int Int
+
+data Action
+  = Recieve (Tuple Int Int)
+  | ChangeBatchCount String
+  | ChangeSegementCount String
+  | Update
+
+batchInputComponent :: forall query m. MonadEffect m => H.Component HH.HTML query (Tuple Int Int) BatchInputMessage m
+batchInputComponent =
+  H.mkComponent
+    { initialState: initialState
+    , render
+    , eval:
+        H.mkEval
+          $ H.defaultEval
+              { handleAction = handleAction
+              , receive = Just <<< Recieve
+              }
+    }
+
+initialState :: (Tuple Int Int) -> State
+initialState (Tuple batchCount segmentCount) =
+  { batchCount: show batchCount
+  , segmentCount: show segmentCount
+  }
+
+render :: forall slots m. State -> HH.ComponentHTML Action slots m
+render state =
+  HH.div_
+    [ HH.label
+        [ HP.for "batchCount" ]
+        [ HH.text "Number of Batches:" ]
+    , HH.input
+        [ HP.type_ HP.InputText
+        , HE.onValueChange $ Just <<< ChangeBatchCount
+        , HP.value state.batchCount
+        , HP.id_ "batchCount"
+        ]
+    , HH.br_
+    , HH.label
+        [ HP.for "segmentCount" ]
+        [ HH.text "Number of Segments per Batch:" ]
+    , HH.input
+        [ HP.type_ HP.InputText
+        , HE.onValueChange $ Just <<< ChangeSegementCount
+        , HP.value state.segmentCount
+        , HP.id_ "segmentCount"
+        ]
+    , HH.br_
+    , HH.p_
+        [ HH.text $ outputMessage state.batchCount state.segmentCount ]
+    , HH.button
+        [ HE.onClick $ toActionEvent Update ]
+        [ HH.text "Update" ]
+    ]
+
+outputMessage :: String -> String -> String
+outputMessage batchCountString segmentCountString = case checkValid batchCountString segmentCountString of
+  Right errorMessage -> errorMessage
+  Left (Tuple batchCount segmentCount) -> "Number of segments: " <> show (batchCount * segmentCount)
+
+toActionEvent :: forall a. Action -> a -> Maybe Action
+toActionEvent action _ = Just action
+
+handleAction :: forall m. MonadEffect m => Action -> H.HalogenM State Action () BatchInputMessage m Unit
+handleAction = case _ of
+  ChangeBatchCount stringInput -> H.modify_ _ { batchCount = stringInput }
+  ChangeSegementCount stringInput -> H.modify_ _ { segmentCount = stringInput }
+  Recieve (Tuple batchCount segmentCount) -> H.modify_ _ { batchCount = show batchCount, segmentCount = show segmentCount }
+  Update -> do
+    state <- H.get
+    case checkValid state.batchCount state.segmentCount of
+      Right errorMessage -> pure unit -- Do nothing
+      Left (Tuple batchCount segmentCount) -> H.raise (UpdatedBatchInput batchCount segmentCount)
+
+checkValid :: String -> String -> Either (Tuple Int Int) String
+checkValid batchCountString segmentCountString = case fromString batchCountString of
+  Nothing -> Right "Failed to parse number of batches"
+  Just batchCount -> case fromString segmentCountString of
+    Nothing -> Right "Failed to parse number of segments per batch"
+    Just segmentCount ->
+      if batchCount < one then
+        Right "Number of batches must be greater than 1"
+      else
+        if segmentCount < one then
+          Right "Number of segments per batch must be greater than 1"
+        else
+          Left (Tuple batchCount segmentCount)

--- a/src/Components/BoundsInput/BoundsInput.purs
+++ b/src/Components/BoundsInput/BoundsInput.purs
@@ -37,7 +37,7 @@ data Bound
   | YUpper
 
 data BoundsInputMessage
-  = Updated XYBounds
+  = UpdatedBoundsInput XYBounds
 
 data Action
   = Init
@@ -170,7 +170,7 @@ handleAction = case _ of
           Nothing -> H.modify_ _ { error = Just $ "Failed to parse lower Y bound" }
           Just yLower -> case maybeYUpper of
             Nothing -> H.modify_ _ { error = Just $ "Failed to parse upper Y bound" }
-            Just yUpper -> H.raise (Updated { xBounds: { lower: xLower, upper: xUpper }, yBounds: { lower: yLower, upper: yUpper } })
+            Just yUpper -> H.raise (UpdatedBoundsInput { xBounds: { lower: xLower, upper: xUpper }, yBounds: { lower: yLower, upper: yUpper } })
 
 parse :: String -> Maybe Rational
 parse input = case runParser input expressionParser of

--- a/src/Components/Main/Action.purs
+++ b/src/Components/Main/Action.purs
@@ -1,6 +1,8 @@
 module Components.Main.Action where
 
 import Prelude
+
+import Components.BatchInput (BatchInputMessage(..))
 import Components.BoundsInput (BoundsInputMessage(..))
 import Components.Canvas (CanvasMessage(..))
 import Components.ExpressionInput (ExpressionInputMessage(..))
@@ -37,6 +39,7 @@ data Action
   | HandleScroll H.SubscriptionId WheelEvent
   | HandleCanvas CanvasMessage
   | HandleBoundsInput BoundsInputMessage
+  | HandleBatchInput BatchInputMessage
   | AddPlot
   | ResetBounds
   | DrawPlot
@@ -70,7 +73,7 @@ handleAction action = do
     ResetBounds -> redrawWithBounds state initialBounds
     HandleCanvas (Dragged delta) -> redrawWithBounds state (panBoundsByVector state.input.size state.bounds delta)
     AddPlot -> H.modify_ (_ { plots = state.plots <> [ newPlot (1 + length state.plots) ] })
-    HandleBoundsInput (Updated newBounds) -> redrawWithBounds state newBounds
+    HandleBoundsInput (UpdatedBoundsInput newBounds) -> redrawWithBounds state newBounds
     Init -> do
       document <- H.liftEffect $ Web.document =<< Web.window
       H.subscribe' \id ->
@@ -95,6 +98,7 @@ handleAction action = do
         handleJobResult maybeJobResult newState
       else
         H.modify_ (_ { queue = clearCancelled state.queue })
+    HandleBatchInput (UpdatedBatchInput batchCount segmentCount) -> H.modify_ (_ { batchCount = batchCount, segmentCount = segmentCount })
 
 handleJobResult :: forall output. Maybe JobResult -> State -> H.HalogenM State Action ChildSlots output (ReaderT Config Aff) Unit
 handleJobResult Nothing _ = pure unit

--- a/src/Components/Main/Action.purs
+++ b/src/Components/Main/Action.purs
@@ -62,7 +62,7 @@ handleAction action = do
 
         updatedQueue = cancelWithBatchId state.queue id
 
-        robust = robustPlot state.bounds expression text
+        robust = robustPlot state.segmentCount state.bounds expression text
 
         withRobust = addPlot state.batchCount updatedQueue robust id
       H.modify_ (_ { plots = plots, queue = withRobust })
@@ -120,7 +120,7 @@ redraw state = do
   let
     canceledQueue = cancelAll state.queue
 
-    robustPlotsWithId = mapMaybe (toMaybePlotCommandWithId state.bounds) state.plots
+    robustPlotsWithId = mapMaybe (toMaybePlotCommandWithId state.segmentCount state.bounds) state.plots
 
     withRobust = addManyPlots state.batchCount canceledQueue robustPlotsWithId
   plots <- lift $ lift $ parSequence $ map (computeExpressionPlot state.input.size state.bounds) state.plots

--- a/src/Components/Main/Action.purs
+++ b/src/Components/Main/Action.purs
@@ -20,7 +20,7 @@ import Plot.JobBatcher (JobResult, addManyPlots, addPlot, cancelAll, cancelWithB
 import Plot.Pan (panBounds, panBoundsByVector)
 import Plot.PlotController (computePlotAsync)
 import Plot.Zoom (zoomBounds)
-import Types (Direction, Id, XYBounds, Size)
+import Types (Direction, Size, XYBounds)
 import Web.Event.Event as E
 import Web.HTML (window) as Web
 import Web.HTML.HTMLDocument as HTMLDocument
@@ -43,9 +43,6 @@ data Action
   | ResetBounds
   | DrawPlot
   | HandleQueue
-
-clearPlotBatchId :: Id
-clearPlotBatchId = 0
 
 handleAction :: forall output. Action -> H.HalogenM State Action ChildSlots output (ReaderT Config Aff) Unit
 handleAction action = do
@@ -138,7 +135,5 @@ computeExpressionPlot :: Size -> XYBounds -> ExpressionPlot -> Aff (ExpressionPl
 computeExpressionPlot size newBounds plot = case plot.expression of
   Nothing -> pure plot
   Just expression -> do
-    let
-      command = roughPlot newBounds expression plot.expressionText
-    drawCommands <- computePlotAsync size command
+    drawCommands <- computePlotAsync size $ roughPlot newBounds expression plot.expressionText
     pure $ plot { drawCommands = drawCommands }

--- a/src/Components/Main/Helper.purs
+++ b/src/Components/Main/Helper.purs
@@ -29,9 +29,9 @@ alterPlot alterF id = map mapper
 initialBounds :: XYBounds
 initialBounds = xyBounds (-one) one (-one) one
 
-toMaybePlotCommandWithId :: XYBounds -> ExpressionPlot -> Maybe (Tuple PlotCommand Id)
-toMaybePlotCommandWithId newBounds plot = case plot.expression of
-  Just expression -> Just $ Tuple (robustPlot newBounds expression plot.expressionText) plot.id
+toMaybePlotCommandWithId :: Int -> XYBounds -> ExpressionPlot -> Maybe (Tuple PlotCommand Id)
+toMaybePlotCommandWithId segmentCount newBounds plot = case plot.expression of
+  Just expression -> Just $ Tuple (robustPlot segmentCount newBounds expression plot.expressionText) plot.id
   Nothing -> Nothing
 
 toMaybeDrawCommand :: ExpressionPlot -> Maybe (DrawCommand Unit)

--- a/src/Components/Main/Main.purs
+++ b/src/Components/Main/Main.purs
@@ -1,18 +1,21 @@
 module Components.Main where
 
 import Prelude
+
+import Components.BatchInput (batchInputComponent)
 import Components.BoundsInput (boundsInputComponent)
 import Components.Canvas (canvasComponent)
 import Components.Canvas.Controller (canvasController)
 import Components.ExpressionInput (expressionInputComponent)
 import Components.ExpressionInput.Controller (expressionInputController)
-import Components.Main.Types (ChildSlots, Config, State)
 import Components.Main.Action (Action(..), handleAction)
 import Components.Main.Helper (initialBounds, newPlot)
+import Components.Main.Types (ChildSlots, Config, State)
 import Constants (canvasId)
 import Control.Monad.Reader (ReaderT)
 import Data.Maybe (Maybe(..))
 import Data.Symbol (SProxy(..))
+import Data.Tuple (Tuple(..))
 import Effect.Aff (Aff)
 import Effect.Class (class MonadEffect)
 import Halogen as H
@@ -27,6 +30,8 @@ _canvas = SProxy :: SProxy "canvas"
 _expressionInput = SProxy :: SProxy "expressionInput"
 
 _boundsInput = SProxy :: SProxy "boundsInput"
+
+_batchInput = SProxy :: SProxy "batchInput"
 
 mainComponent :: forall query input output. H.Component HH.HTML query input output (ReaderT Config Aff)
 mainComponent =
@@ -58,6 +63,8 @@ mainComponent =
     , commandSetId: 0
     , clearPlot: pure unit
     , queue: initialJobQueue
+    , batchCount: 5
+    , segmentCount : 10
     }
 
   render :: forall m. MonadEffect m => State -> H.ComponentHTML Action ChildSlots m
@@ -74,6 +81,7 @@ mainComponent =
             [ HE.onClick $ toActionEvent Clear ]
             [ HH.text "Clear plots" ]
         , HH.slot _boundsInput 1 boundsInputComponent state.bounds (Just <<< HandleBoundsInput)
+        , HH.slot _batchInput 1 batchInputComponent (Tuple state.batchCount state.segmentCount) (Just <<< HandleBatchInput)
         , HH.button
             [ HE.onClick $ toActionEvent $ ResetBounds ]
             [ HH.text "Reset" ]

--- a/src/Components/Main/Types.purs
+++ b/src/Components/Main/Types.purs
@@ -1,14 +1,16 @@
 module Components.Main.Types where
 
 import Prelude
+
+import Components.BatchInput (BatchInputSlot)
+import Components.BoundsInput (BoundsInputSlot)
 import Components.Canvas (CanvasSlot, Input)
+import Components.ExpressionInput (ExpressionInputSlot)
 import Data.Maybe (Maybe)
 import Draw.Commands (DrawCommand)
 import Expression.Syntax (Expression)
 import Plot.JobBatcher (JobQueue)
 import Types (XYBounds)
-import Components.BoundsInput (BoundsInputSlot)
-import Components.ExpressionInput (ExpressionInputSlot)
 
 type State
   = { input :: Input (DrawCommand Unit)
@@ -17,6 +19,8 @@ type State
     , commandSetId :: Int
     , clearPlot :: DrawCommand Unit
     , queue :: JobQueue
+    , batchCount :: Int
+    , segmentCount :: Int
     }
 
 type ExpressionPlot
@@ -30,6 +34,7 @@ type ChildSlots
   = ( canvas :: CanvasSlot Int
     , expressionInput :: ExpressionInputSlot Int
     , boundsInput :: BoundsInputSlot Int
+    , batchInput :: BatchInputSlot Int
     )
 
 type Config

--- a/src/Plot/Commands.purs
+++ b/src/Plot/Commands.purs
@@ -7,13 +7,13 @@ import Types (XYBounds, Bounds)
 data PlotCommand
   = Empty XYBounds
   | RoughPlot XYBounds Expression String
-  | RobustPlot XYBounds Bounds Expression String
+  | RobustPlot Int XYBounds Bounds Expression String
 
 roughPlot :: XYBounds -> Expression -> String -> PlotCommand
 roughPlot = RoughPlot
 
-robustPlot :: XYBounds -> Expression -> String -> PlotCommand
-robustPlot bounds expression label = RobustPlot bounds bounds.xBounds expression label
+robustPlot :: Int -> XYBounds -> Expression -> String -> PlotCommand
+robustPlot segmentCount bounds expression label = RobustPlot segmentCount bounds bounds.xBounds expression label
 
 clear :: XYBounds -> PlotCommand
 clear = Empty
@@ -23,11 +23,11 @@ isPlotExpression (RoughPlot _ _ _) = true
 
 isPlotExpression (Empty _) = false
 
-isPlotExpression (RobustPlot _ _ _ _) = true
+isPlotExpression (RobustPlot _ _ _ _ _) = true
 
 derive instance plotCommandEq :: Eq PlotCommand
 
 instance plotCommandShow :: Show PlotCommand where
   show (Empty bounds) = "Empty " <> (show bounds)
   show (RoughPlot bounds expression label) = "RoughPlot " <> (show bounds) <> " " <> (show expression) <> " " <> label
-  show (RobustPlot bounds fullXBounds expression label) = "RobustPlot " <> (show bounds) <> " " <> (show fullXBounds) <> " " <> (show expression) <> " " <> label
+  show (RobustPlot segmentCount bounds fullXBounds expression label) = "RobustPlot " <> (show segmentCount) <> " " <> (show bounds) <> " " <> (show fullXBounds) <> " " <> (show expression) <> " " <> label

--- a/src/Plot/PlotController.purs
+++ b/src/Plot/PlotController.purs
@@ -24,4 +24,4 @@ runCommand _ (Empty bounds) = clearAndDrawGridLines bounds
 
 runCommand canvasSize (RoughPlot bounds expression label) = drawRoughPlot canvasSize bounds expression label
 
-runCommand canvasSize (RobustPlot bounds fullXBounds expression label) = drawRobustPlot canvasSize fullXBounds bounds expression label
+runCommand canvasSize (RobustPlot segmentCount bounds fullXBounds expression label) = drawRobustPlot segmentCount canvasSize fullXBounds bounds expression label

--- a/src/Plot/RobustPlot.purs
+++ b/src/Plot/RobustPlot.purs
@@ -16,15 +16,12 @@ import IntervalArith.Approx (Approx, boundsNumber, fromRationalBoundsPrec)
 import IntervalArith.Misc (Rational, rationalToNumber, toRational)
 import Types (Polygon, Position, Size, XYBounds, Bounds)
 
-segmentCount :: Int
-segmentCount = 10
-
-drawRobustPlot :: Size -> Bounds -> XYBounds -> Expression -> String -> DrawCommand Unit
-drawRobustPlot canvasSize fullXBounds bounds expression label = drawCommands
+drawRobustPlot :: Int -> Size -> Bounds -> XYBounds -> Expression -> String -> DrawCommand Unit
+drawRobustPlot segmentCount canvasSize fullXBounds bounds expression label = drawCommands
   where
   f = evaluateWithX expression
 
-  segmentEnclosures = plotEnclosures canvasSize fullXBounds bounds f
+  segmentEnclosures = plotEnclosures segmentCount canvasSize fullXBounds bounds f
 
   drawCommands = drawPlot segmentEnclosures
 
@@ -37,8 +34,8 @@ evaluateWithX expression x = value
     Left _ -> zero -- TODO Handle any evaluation erros 
     Right v -> v
 
-plotEnclosures :: Size -> Bounds -> XYBounds -> (Approx -> Approx) -> Array Polygon
-plotEnclosures canvasSize fullXBounds bounds f = segmentEnclosures
+plotEnclosures :: Int -> Size -> Bounds -> XYBounds -> (Approx -> Approx) -> Array Polygon
+plotEnclosures segmentCount canvasSize fullXBounds bounds f = segmentEnclosures
   where
   rangeX = bounds.xBounds.upper - bounds.xBounds.lower
 

--- a/test/Plot/JobBatcher/AddPlot.purs
+++ b/test/Plot/JobBatcher/AddPlot.purs
@@ -39,9 +39,9 @@ addPlotTests =
         Left error -> failure (show error)
         Right expression -> do
           let
-            plotCommand = robustPlot bounds expression label
+            plotCommand = robustPlot 10 bounds expression label
 
-            queueWithPlot = addPlot emptyQueue plotCommand batchId
+            queueWithPlot = addPlot 5 emptyQueue plotCommand batchId
 
             checkJobWithCommonInfo = checkJob bounds label expression batchId
 
@@ -59,7 +59,7 @@ checkJob _ _ _ _ id _ _ Nothing = failure $ "Expected Job " <> (show id) <> " bu
 checkJob fullBounds label expression batchId id lower upper (Just job) = do
   equal id job.id
   equal batchId job.batchId
-  equal (RobustPlot (fullBounds { xBounds = { lower, upper } }) fullBounds.xBounds expression label) job.command
+  equal (RobustPlot 10 (fullBounds { xBounds = { lower, upper } }) fullBounds.xBounds expression label) job.command
 
 parseAndSimplify :: String -> Expect Expression
 parseAndSimplify rawExpression = valueOrEvaluationError


### PR DESCRIPTION
# Issues
closes #53 
closes #51 

# Summary of changes
- Added `BatchInput` component which contains the input for the 'number of batches' and the 'number of segments per batch'. Error reporting occurs as the data is changed as parsing String into an Int is cheap.
- Deleted `clearPlotBatchId` as it was unused
- Added the `batchCount` and `segmentCount` to the `State`
- Refactored `redrawWithBounds` into `redraw` as has the same functionality as a `redraw` function the only difference is that it also updates the bounds in the state.
- Added the `batchCount` as a parameter for the `JobBatcher`
- Added `segmentCount` as a parameter for the `RobustPlot` plot command
- Removed `batchSegmentCount` and `segmentCount` constants as they're unused

# Tests
- Test.Plot.JobBatcher.AddPlot (Fixed)