### PR TITLE
Pan and Zoom delay robust plot

### DIFF
--- a/src/Components/Canvas/Canvas.purs
+++ b/src/Components/Canvas/Canvas.purs
@@ -30,7 +30,8 @@ type State operations
     }
 
 data CanvasMessage
-  = Dragged Delta
+  = Dragged Delta 
+  | StoppedDragging
 
 type Input operations
   = { operations :: operations
@@ -100,7 +101,9 @@ handleAction controller = case _ of
     pure unit
   StartDrag delta -> do
     H.modify_ _ { oldDelta = delta, isDragging = true }
-  EndDrag -> H.modify_ _ { isDragging = false }
+  EndDrag -> do 
+    H.modify_ _ { isDragging = false }
+    H.raise StoppedDragging 
   Drag delta -> do
     state <- H.get
     when state.isDragging do

--- a/src/Components/Main/Action.purs
+++ b/src/Components/Main/Action.purs
@@ -140,13 +140,9 @@ redrawWithBounds state newBounds = do
 
 redrawWithoutRobustWithBounds :: forall output. State -> XYBounds -> H.HalogenM State Action ChildSlots output (ReaderT Config Aff) Unit
 redrawWithoutRobustWithBounds state newBounds = do
-  let
-    canceledQueue = cancelAll state.queue
-
-    robustPlotsWithId = mapMaybe (toMaybePlotCommandWithId state.segmentCount newBounds) state.plots
   plots <- lift $ lift $ parSequence $ map (computeExpressionPlot state.input.size newBounds) state.plots
   clearBounds <- lift $ lift $ computePlotAsync state.input.size (clear newBounds)
-  H.modify_ (_ { plots = plots, queue = canceledQueue, clearPlot = clearBounds, bounds = newBounds })
+  H.modify_ (_ { plots = plots, queue = cancelAll state.queue, clearPlot = clearBounds, bounds = newBounds })
   handleAction DrawPlot
 
 computeExpressionPlot :: Size -> XYBounds -> ExpressionPlot -> Aff (ExpressionPlot)


### PR DESCRIPTION
# Issues
closes #67 

# Summary of changes
- Added `forkWithDelay` which is the same as `fork` only it specifies the number of milliseconds to wait. It should be noted that this delay is not constant. It is the minimum delay.
- Updated the mouse zoom and drag pan to no longer trigger the robust drawing until the user stops. For the mouse drag pan, this means waiting until the mouse up event to trigger the robust plot. For the mouse zoom, this means delaying the robust drawing for 0.5 seconds (as specified in the issue).
- Delay also occurs when pressing the various canvas control buttons aswell

# Tests
N/A