### PR TITLE
Moved bounds input and added expression name

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,10 @@
     .card-body {
       margin: 10px;
     }
+
+    .small-input {
+      max-width: 80px
+    }
   </style>
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css"
     integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">

--- a/src/Components/AccuracyInput/AccuracyInput.purs
+++ b/src/Components/AccuracyInput/AccuracyInput.purs
@@ -61,7 +61,7 @@ render state =
               , HP.class_ (ClassName "form-control")
               ]
           , HH.button
-              [ HE.onClick $ toActionEvent Update, HP.class_ (ClassName "btn btn-info") ]
+              [ HE.onClick $ toActionEvent Update, HP.class_ (ClassName "btn btn-primary") ]
               [ HH.text "Update" ]
           ]
       ]

--- a/src/Components/BatchInput/BatchInput.purs
+++ b/src/Components/BatchInput/BatchInput.purs
@@ -62,7 +62,7 @@ render state =
               , HP.class_ (ClassName "form-control")
               ]
           , HH.button
-              [ HE.onClick $ toActionEvent Update, HP.class_ (ClassName "btn btn-info") ]
+              [ HE.onClick $ toActionEvent Update, HP.class_ (ClassName "btn btn-primary") ]
               [ HH.text "Update" ]
           ]
       ]

--- a/src/Components/BoundsInput/BoundsInput.purs
+++ b/src/Components/BoundsInput/BoundsInput.purs
@@ -21,6 +21,7 @@ type BoundsInputSlot p
 
 type State
   = { error :: Maybe String
+    , oldBounds :: XYBounds
     , xBounds ::
         { upper :: String
         , lower :: String
@@ -41,8 +42,7 @@ data BoundsInputMessage
   = UpdatedBoundsInput XYBounds
 
 data Action
-  = Init
-  | Recieve XYBounds
+  = Recieve XYBounds
   | HandleInput Bound String
   | Update
   | ResetBounds
@@ -57,13 +57,13 @@ boundsInputComponent =
           $ H.defaultEval
               { handleAction = handleAction
               , receive = Just <<< Recieve
-              , initialize = Just Init
               }
     }
 
 initialState :: XYBounds -> State
 initialState input =
   { error: Nothing
+  , oldBounds: input
   , xBounds:
       { upper: show $ rationalToNumber input.xBounds.upper
       , lower: show $ rationalToNumber input.xBounds.lower
@@ -77,95 +77,54 @@ initialState input =
 render :: forall slots m. State -> HH.ComponentHTML Action slots m
 render state =
   HH.div
-    [ HP.class_ (ClassName "card")
-    ]
-    [ HH.div
-        [ HP.class_ (ClassName "card-header") ]
-        [ HH.text "Bound controls" ]
-    , HH.div
-        [ HP.class_ (ClassName "card-body") ]
-        ( [ HH.div
-              [ HP.class_ (ClassName "row") ]
-              [ HH.div
-                  [ HP.class_ (ClassName "col-md") ]
-                  [ HH.div
-                      [ HP.class_ (ClassName "input-group mb-3") ]
-                      [ HH.div
-                          [ HP.class_ (ClassName "input-group-prepend") ]
-                          [ HH.span [ HP.class_ (ClassName "input-group-text") ] [ HH.text "Lower X:" ] ]
-                      , HH.input
-                          [ HP.type_ HP.InputText
-                          , HE.onValueChange $ toValueChangeActionEvent XLower
-                          , HP.value state.xBounds.lower
-                          , HP.class_ (ClassName "form-control")
-                          ]
-                      ]
-                  ]
-              , HH.div
-                  [ HP.class_ (ClassName "col-md") ]
-                  [ HH.div
-                      [ HP.class_ (ClassName "input-group mb-3") ]
-                      [ HH.div
-                          [ HP.class_ (ClassName "input-group-prepend") ]
-                          [ HH.span [ HP.class_ (ClassName "input-group-text") ] [ HH.text "Upper X:" ] ]
-                      , HH.input
-                          [ HP.type_ HP.InputText
-                          , HE.onValueChange $ toValueChangeActionEvent XUpper
-                          , HP.value state.xBounds.upper
-                          , HP.class_ (ClassName "form-control")
-                          ]
-                      ]
-                  ]
+    [ HP.class_ (ClassName "form-inline") ]
+    $ [ HH.div
+          [ HP.class_ (ClassName "pr-2") ]
+          [ HH.input
+              [ HP.type_ HP.InputText
+              , HE.onValueChange $ toValueChangeActionEvent XLower
+              , HP.value state.xBounds.lower
+              , HE.onFocusOut $ toActionEvent Update
+              , HP.class_ (ClassName "form-control small-input")
               ]
-          , HH.div
-              [ HP.class_ (ClassName "row") ]
-              [ HH.div
-                  [ HP.class_ (ClassName "col-md") ]
-                  [ HH.div
-                      [ HP.class_ (ClassName "input-group mb-3") ]
-                      [ HH.div
-                          [ HP.class_ (ClassName "input-group-prepend") ]
-                          [ HH.span [ HP.class_ (ClassName "input-group-text") ] [ HH.text "Lower Y:" ] ]
-                      , HH.input
-                          [ HP.type_ HP.InputText
-                          , HE.onValueChange $ toValueChangeActionEvent YLower
-                          , HP.value state.yBounds.lower
-                          , HP.class_ (ClassName "form-control")
-                          ]
-                      ]
-                  ]
-              , HH.div
-                  [ HP.class_ (ClassName "col-md") ]
-                  [ HH.div
-                      [ HP.class_ (ClassName "input-group mb-3") ]
-                      [ HH.div
-                          [ HP.class_ (ClassName "input-group-prepend") ]
-                          [ HH.span [ HP.class_ (ClassName "input-group-text") ] [ HH.text "Upper Y:" ] ]
-                      , HH.input
-                          [ HP.type_ HP.InputText
-                          , HE.onValueChange $ toValueChangeActionEvent YUpper
-                          , HP.value state.yBounds.upper
-                          , HP.class_ (ClassName "form-control")
-                          ]
-                      ]
-                  ]
+          , HH.span [ HP.class_ (ClassName "") ] [ HH.text " ≤ x ≤ " ]
+          , HH.input
+              [ HP.type_ HP.InputText
+              , HE.onValueChange $ toValueChangeActionEvent XUpper
+              , HP.value state.xBounds.upper
+              , HE.onFocusOut $ toActionEvent Update
+              , HP.class_ (ClassName "form-control small-input")
               ]
           ]
-            <> (errorMessage state.error)
-        )
-    , HH.div
-        [ HP.class_ (ClassName "card-footer") ]
-        [ HH.div
-            [ HP.class_ (ClassName "btn-group") ]
-            [ HH.button
-                [ HE.onClick $ toActionEvent Update, HP.class_ (ClassName "btn btn-success") ]
-                [ HH.text "Update" ]
-            , HH.button
-                [ HP.class_ (ClassName "btn btn-danger"), HE.onClick $ toActionEvent $ ResetBounds ]
-                [ HH.text "Reset" ]
-            ]
-        ]
-    ]
+      , HH.div
+          [ HP.class_ (ClassName "pr-2") ]
+          [ HH.input
+              [ HP.type_ HP.InputText
+              , HE.onValueChange $ toValueChangeActionEvent YLower
+              , HP.value state.yBounds.lower
+              , HE.onFocusOut $ toActionEvent Update
+              , HP.class_ (ClassName "form-control small-input")
+              ]
+          , HH.span [ HP.class_ (ClassName "") ] [ HH.text " ≤ y ≤ " ]
+          , HH.input
+              [ HP.type_ HP.InputText
+              , HE.onValueChange $ toValueChangeActionEvent YUpper
+              , HE.onFocusOut $ toActionEvent Update
+              , HP.value state.yBounds.upper
+              , HP.class_ (ClassName "form-control small-input")
+              ]
+          ]
+      , HH.div
+          [ HP.class_ (ClassName "btn-group") ]
+          [ HH.button
+              [ HE.onClick $ toActionEvent Update, HP.class_ (ClassName "btn btn-success") ]
+              [ HH.text "Update bounds" ]
+          , HH.button
+              [ HP.class_ (ClassName "btn btn-danger"), HE.onClick $ toActionEvent $ ResetBounds ]
+              [ HH.text "Reset bounds" ]
+          ]
+      ]
+    <> (errorMessage state.error)
 
 toValueChangeActionEvent :: Bound -> String -> Maybe Action
 toValueChangeActionEvent bound value = Just $ HandleInput bound value
@@ -184,12 +143,6 @@ errorMessage (Just message) =
 
 handleAction :: forall m. MonadEffect m => Action -> H.HalogenM State Action () BoundsInputMessage m Unit
 handleAction = case _ of
-  Init -> do
-    { xBounds, yBounds } <- H.get
-    handleAction (HandleInput XLower $ xBounds.lower)
-    handleAction (HandleInput XUpper $ xBounds.upper)
-    handleAction (HandleInput YLower $ yBounds.lower)
-    handleAction (HandleInput YUpper $ yBounds.upper)
   HandleInput XLower stringInput -> H.modify_ _ { xBounds { lower = stringInput } }
   HandleInput XUpper stringInput -> H.modify_ _ { xBounds { upper = stringInput } }
   HandleInput YLower stringInput -> H.modify_ _ { yBounds { lower = stringInput } }
@@ -206,9 +159,10 @@ handleAction = case _ of
           { upper = show $ rationalToNumber bounds.yBounds.upper
           , lower = show $ rationalToNumber bounds.yBounds.lower
           }
+        , oldBounds = bounds
         }
   Update -> do
-    { xBounds, yBounds } <- H.get
+    { xBounds, yBounds, oldBounds } <- H.get
     let
       maybeXLower = parse xBounds.lower
 
@@ -226,8 +180,11 @@ handleAction = case _ of
           Just yLower -> case maybeYUpper of
             Nothing -> H.modify_ _ { error = Just $ "Failed to parse upper Y bound" }
             Just yUpper -> do
+              let
+                newBounds = xyBounds xLower xUpper yLower yUpper
               H.modify_ _ { error = Nothing }
-              H.raise (UpdatedBoundsInput { xBounds: { lower: xLower, upper: xUpper }, yBounds: { lower: yLower, upper: yUpper } })
+              when (oldBounds /= newBounds)
+                $ H.raise (UpdatedBoundsInput newBounds)
 
 parse :: String -> Maybe Rational
 parse input = case runParser input expressionParser of

--- a/src/Components/BoundsInput/BoundsInput.purs
+++ b/src/Components/BoundsInput/BoundsInput.purs
@@ -76,49 +76,51 @@ initialState input =
 
 render :: forall slots m. State -> HH.ComponentHTML Action slots m
 render state =
-  HH.div
-    [ HP.class_ (ClassName "form-inline") ]
+  HH.div_
     $ [ HH.div
-          [ HP.class_ (ClassName "pr-2") ]
-          [ HH.input
-              [ HP.type_ HP.InputText
-              , HE.onValueChange $ toValueChangeActionEvent XLower
-              , HP.value state.xBounds.lower
-              , HE.onFocusOut $ toActionEvent Update
-              , HP.class_ (ClassName "form-control small-input")
+          [ HP.class_ (ClassName "form-inline") ]
+          [ HH.div
+              [ HP.class_ (ClassName "pr-2") ]
+              [ HH.input
+                  [ HP.type_ HP.InputText
+                  , HE.onValueChange $ toValueChangeActionEvent XLower
+                  , HP.value state.xBounds.lower
+                  , HE.onFocusOut $ toActionEvent Update
+                  , HP.class_ (ClassName "form-control small-input")
+                  ]
+              , HH.span [ HP.class_ (ClassName "") ] [ HH.text " ≤ x ≤ " ]
+              , HH.input
+                  [ HP.type_ HP.InputText
+                  , HE.onValueChange $ toValueChangeActionEvent XUpper
+                  , HP.value state.xBounds.upper
+                  , HE.onFocusOut $ toActionEvent Update
+                  , HP.class_ (ClassName "form-control small-input")
+                  ]
               ]
-          , HH.span [ HP.class_ (ClassName "") ] [ HH.text " ≤ x ≤ " ]
-          , HH.input
-              [ HP.type_ HP.InputText
-              , HE.onValueChange $ toValueChangeActionEvent XUpper
-              , HP.value state.xBounds.upper
-              , HE.onFocusOut $ toActionEvent Update
-              , HP.class_ (ClassName "form-control small-input")
+          , HH.div
+              [ HP.class_ (ClassName "pr-2") ]
+              [ HH.input
+                  [ HP.type_ HP.InputText
+                  , HE.onValueChange $ toValueChangeActionEvent YLower
+                  , HP.value state.yBounds.lower
+                  , HE.onFocusOut $ toActionEvent Update
+                  , HP.class_ (ClassName "form-control small-input")
+                  ]
+              , HH.span [ HP.class_ (ClassName "") ] [ HH.text " ≤ y ≤ " ]
+              , HH.input
+                  [ HP.type_ HP.InputText
+                  , HE.onValueChange $ toValueChangeActionEvent YUpper
+                  , HE.onFocusOut $ toActionEvent Update
+                  , HP.value state.yBounds.upper
+                  , HP.class_ (ClassName "form-control small-input")
+                  ]
               ]
-          ]
-      , HH.div
-          [ HP.class_ (ClassName "pr-2") ]
-          [ HH.input
-              [ HP.type_ HP.InputText
-              , HE.onValueChange $ toValueChangeActionEvent YLower
-              , HP.value state.yBounds.lower
-              , HE.onFocusOut $ toActionEvent Update
-              , HP.class_ (ClassName "form-control small-input")
+          , HH.div
+              [ HP.class_ (ClassName "btn-group") ]
+              [ HH.button
+                  [ HP.class_ (ClassName "btn btn-warning"), HE.onClick $ toActionEvent $ ResetBounds ]
+                  [ HH.text "Reset bounds" ]
               ]
-          , HH.span [ HP.class_ (ClassName "") ] [ HH.text " ≤ y ≤ " ]
-          , HH.input
-              [ HP.type_ HP.InputText
-              , HE.onValueChange $ toValueChangeActionEvent YUpper
-              , HE.onFocusOut $ toActionEvent Update
-              , HP.value state.yBounds.upper
-              , HP.class_ (ClassName "form-control small-input")
-              ]
-          ]
-      , HH.div
-          [ HP.class_ (ClassName "btn-group") ]
-          [ HH.button
-              [ HP.class_ (ClassName "btn btn-warning"), HE.onClick $ toActionEvent $ ResetBounds ]
-              [ HH.text "Reset bounds" ]
           ]
       ]
     <> (errorMessage state.error)
@@ -144,7 +146,9 @@ handleAction = case _ of
   HandleInput XUpper stringInput -> H.modify_ _ { xBounds { upper = stringInput } }
   HandleInput YLower stringInput -> H.modify_ _ { yBounds { lower = stringInput } }
   HandleInput YUpper stringInput -> H.modify_ _ { yBounds { upper = stringInput } }
-  ResetBounds -> H.raise (UpdatedBoundsInput initialBounds)
+  ResetBounds -> do
+    H.modify_ _ { error = Nothing }
+    H.raise (UpdatedBoundsInput initialBounds)
   Recieve bounds ->
     H.modify_
       _
@@ -157,6 +161,7 @@ handleAction = case _ of
           , lower = show $ rationalToNumber bounds.yBounds.lower
           }
         , oldBounds = bounds
+        , error = Nothing
         }
   Update -> do
     { xBounds, yBounds, oldBounds } <- H.get

--- a/src/Components/BoundsInput/BoundsInput.purs
+++ b/src/Components/BoundsInput/BoundsInput.purs
@@ -117,10 +117,7 @@ render state =
       , HH.div
           [ HP.class_ (ClassName "btn-group") ]
           [ HH.button
-              [ HE.onClick $ toActionEvent Update, HP.class_ (ClassName "btn btn-success") ]
-              [ HH.text "Update bounds" ]
-          , HH.button
-              [ HP.class_ (ClassName "btn btn-danger"), HE.onClick $ toActionEvent $ ResetBounds ]
+              [ HP.class_ (ClassName "btn btn-warning"), HE.onClick $ toActionEvent $ ResetBounds ]
               [ HH.text "Reset bounds" ]
           ]
       ]

--- a/src/Components/ExpressionInput/ExpressionInput.purs
+++ b/src/Components/ExpressionInput/ExpressionInput.purs
@@ -83,7 +83,7 @@ render state =
                   ]
               , HH.button
                   [ HP.type_ ButtonButton
-                  , HP.class_ (ClassName "btn btn-info")
+                  , HP.class_ (ClassName "btn btn-primary")
                   , HE.onClick $ toActionEvent Parse
                   ]
                   [ HH.text "Plot" ]

--- a/src/Components/ExpressionManager/ExpressionManager.purs
+++ b/src/Components/ExpressionManager/ExpressionManager.purs
@@ -1,0 +1,201 @@
+module Components.ExpressionManager where
+
+import Prelude
+import Components.ExpressionInput (ExpressionInputMessage, expressionInputComponent)
+import Components.ExpressionInput.Controller (expressionInputController)
+import Components.ExpressionManager.Types (ExpressionPlot, ChildSlots)
+import Data.Array (filter, find, head, length)
+import Data.Maybe (Maybe(..), fromMaybe, isJust)
+import Data.Symbol (SProxy(..))
+import Data.Tuple (Tuple(..))
+import Effect.Class (class MonadEffect)
+import Halogen (ClassName(..))
+import Halogen as H
+import Halogen.HTML as HH
+import Halogen.HTML.Events as HE
+import Halogen.HTML.Properties as HP
+
+_expressionInput = SProxy :: SProxy "expressionInput"
+
+type ExpressionManagerSlot p
+  = forall q. H.Slot q ExpressionManagerMessage p
+
+type State
+  = { plots :: Array ExpressionPlot
+    , selectedPlotId :: Int
+    , nextPlotId :: Int
+    , editingSelected :: Boolean
+    }
+
+data ExpressionManagerMessage
+  = AddPlot Int
+  | ClearPlots
+  | DeletePlot Int
+  | RenamePlot Int String
+  | RaisedExpressionInputMessage ExpressionInputMessage
+
+data Action
+  = HandleMessage (Array ExpressionPlot)
+  | Clear
+  | Add
+  | Delete Int
+  | Edit
+  | Rename
+  | HandleInput String
+  | ChangeSelected Int
+  | HandleExpressionInput ExpressionInputMessage
+
+expressionManagerComponent :: forall query m. MonadEffect m => H.Component HH.HTML query (Array ExpressionPlot) ExpressionManagerMessage m
+expressionManagerComponent =
+  H.mkComponent
+    { initialState
+    , render
+    , eval:
+        H.mkEval
+          $ H.defaultEval
+              { handleAction = handleAction
+              , receive = Just <<< HandleMessage
+              }
+    }
+
+initialState :: Array ExpressionPlot -> State
+initialState plots =
+  { plots
+  , selectedPlotId: fromMaybe 0 $ (_.id) <$> (head plots)
+  , editingSelected: false
+  , nextPlotId: 1
+  }
+
+render :: forall m. MonadEffect m => State -> HH.ComponentHTML Action ChildSlots m
+render state =
+  HH.div_
+    [ HH.div
+        [ HP.class_ (ClassName "card") ]
+        [ HH.div
+            [ HP.class_ (ClassName "card-header") ]
+            [ HH.ul
+                [ HP.class_ (ClassName "nav nav-tabs card-header-tabs") ]
+                (map (toTab (1 < length state.plots) state.editingSelected state.selectedPlotId) state.plots)
+            ]
+        , HH.div
+            [ HP.class_ (ClassName "card-body") ]
+            [ tabContent state.plots state.selectedPlotId
+            ]
+        , HH.div
+            [ HP.class_ (ClassName "card-footer") ]
+            [ HH.div
+                [ HP.class_ (ClassName "btn-group") ]
+                [ HH.button
+                    [ HP.class_ (ClassName "btn btn-primary"), HE.onClick $ toActionEvent $ Add ]
+                    [ HH.text "Add plot" ]
+                , HH.button
+                    [ HP.class_ (ClassName "btn btn-danger"), HE.onClick $ toActionEvent Clear ]
+                    [ HH.text "Clear plots" ]
+                ]
+            ]
+        ]
+    ]
+
+toValueChangeActionEvent :: String -> Maybe Action
+toValueChangeActionEvent value = Just $ HandleInput value
+
+toActionEvent :: forall a. Action -> a -> Maybe Action
+toActionEvent action _ = Just action
+
+handleAction :: forall m. MonadEffect m => Action -> H.HalogenM State Action ChildSlots ExpressionManagerMessage m Unit
+handleAction = case _ of
+  HandleMessage plots -> do
+    { selectedPlotId } <- H.get
+    let
+      newSelectedPlotId = if plotExists plots selectedPlotId then selectedPlotId else fromMaybe 0 $ (_.id) <$> (head plots)
+    H.modify_ _ { plots = plots, selectedPlotId = newSelectedPlotId, editingSelected = false }
+  Clear -> H.raise ClearPlots
+  Add -> do
+    { nextPlotId } <- H.get
+    H.modify_ (_ { nextPlotId = nextPlotId + 1 })
+    H.raise (AddPlot nextPlotId)
+  Delete plotId -> do H.raise $ DeletePlot plotId
+  Edit -> H.modify_ (_ { editingSelected = true })
+  Rename -> do
+    { selectedPlotId } <- H.get
+    H.raise $ RenamePlot selectedPlotId "" -- TODO: retreieve input from text
+  HandleInput value -> pure unit
+  ChangeSelected plotId -> do
+    { selectedPlotId, plots } <- H.get
+    when ((plotExists plots plotId) && selectedPlotId /= plotId) do
+      H.modify_ (_ { selectedPlotId = plotId, editingSelected = false })
+  HandleExpressionInput message -> H.raise $ RaisedExpressionInputMessage message
+
+toTab :: forall w. Boolean -> Boolean -> Int -> ExpressionPlot -> HH.HTML w Action
+toTab allowDelete editingSelected selectedId plot =
+  HH.li
+    [ HP.class_ (ClassName "nav-item") ]
+    [ HH.button
+        [ HP.class_ (ClassName ("nav-link" <> maybeActiveClass))
+        , (HE.onClick (toActionEvent (ChangeSelected plot.id)))
+        ]
+        ( input <> editButton <> cross
+        )
+    ]
+  where
+  isSelected = selectedId == plot.id
+
+  addPaddingToInput = allowDelete || not editingSelected
+
+  maybeActiveClass = if isSelected then " active" else ""
+
+  text = if plot.expressionText == "" then "Plot " <> (show plot.id) else plot.expressionText
+
+  input =
+    if editingSelected then
+      [ HH.input
+          [ HP.type_ HP.InputText
+          , HE.onFocusOut $ toActionEvent Rename
+          , HE.onValueChange $ toValueChangeActionEvent
+          , HP.value text
+          , HP.class_ (ClassName $ if addPaddingToInput then "form-control small-input pr-2" else "form-control small-input")
+          ]
+      ]
+    else
+      [ HH.span
+          [ HP.class_ (ClassName $ if addPaddingToInput then "pr-2" else "") ]
+          [ HH.text text ]
+      ]
+
+  editButton =
+    if isSelected && not editingSelected then
+      [ HH.button
+          [ HP.class_ (ClassName "close")
+          , HE.onClick $ toActionEvent Edit
+          ]
+          [ HH.text "🖉" ]
+      ]
+    else
+      []
+
+  cross =
+    if allowDelete then
+      [ HH.button
+          [ HP.class_ (ClassName "close")
+          , HE.onClick $ toActionEvent (Delete plot.id)
+          ]
+          [ HH.text "✕" ]
+      ]
+    else
+      []
+
+tabContent :: forall m. MonadEffect m => Array ExpressionPlot -> Int -> H.ComponentHTML Action ChildSlots m
+tabContent [] _ = HH.text "Error: No plots"
+
+tabContent plots selectedId = case find (\p -> p.id == selectedId) plots of
+  Nothing -> HH.text $ "Error: Plot " <> (show selectedId) <> " does not exist"
+  Just plot -> HH.slot _expressionInput plot.id component input toAction
+    where
+    component = expressionInputComponent expressionInputController plot.id
+
+    input = Tuple plot.expressionText plot.status
+
+    toAction = Just <<< HandleExpressionInput
+
+plotExists :: Array ExpressionPlot -> Int -> Boolean
+plotExists plots plotId = isJust (find (\p -> p.id == plotId) plots)

--- a/src/Components/ExpressionManager/Types.purs
+++ b/src/Components/ExpressionManager/Types.purs
@@ -15,6 +15,7 @@ type ExpressionPlot
     , id :: Int
     , queue :: JobQueue
     , status :: Status
+    , name :: String
     }
 
 type ChildSlots

--- a/src/Components/ExpressionManager/Types.purs
+++ b/src/Components/ExpressionManager/Types.purs
@@ -1,0 +1,22 @@
+module Components.ExpressionManager.Types where
+
+import Prelude
+import Components.ExpressionInput (ExpressionInputSlot, Status)
+import Data.Maybe (Maybe)
+import Draw.Commands (DrawCommand)
+import Expression.Syntax (Expression)
+import Plot.JobBatcher (JobQueue)
+
+type ExpressionPlot
+  = { expression :: Maybe Expression
+    , expressionText :: String
+    , robustDrawCommands :: DrawCommand Unit
+    , roughDrawCommands :: DrawCommand Unit
+    , id :: Int
+    , queue :: JobQueue
+    , status :: Status
+    }
+
+type ChildSlots
+  = ( expressionInput :: ExpressionInputSlot Int
+    )

--- a/src/Components/Main/Action.purs
+++ b/src/Components/Main/Action.purs
@@ -158,7 +158,7 @@ handleExpressionPlotMessage state (DeletePlot plotId) = do
 
 handleExpressionPlotMessage state (AddPlot nextId) = H.modify_ (_ { plots = state.plots <> [ newPlot nextId ] })
 
-handleExpressionPlotMessage state (RenamePlot plotId name) = pure unit -- TODO: Add name to state
+handleExpressionPlotMessage state (RenamePlot plotId name) = H.modify_ (_ { plots = alterPlot (_ { name = name }) plotId state.plots })
 
 handleExpressionPlotMessage state ClearPlots = clearAction state
 

--- a/src/Components/Main/Helper.purs
+++ b/src/Components/Main/Helper.purs
@@ -3,7 +3,8 @@ module Components.Main.Helper where
 import Prelude
 
 import Components.ExpressionInput (Status(..))
-import Components.Main.Types (ExpressionPlot, State)
+import Components.ExpressionManager.Types (ExpressionPlot)
+import Components.Main.Types (State)
 import Control.Parallel (parSequence)
 import Data.Array (cons, fold, foldl, mapMaybe, uncons)
 import Data.Maybe (Maybe(..))

--- a/src/Components/Main/Helper.purs
+++ b/src/Components/Main/Helper.purs
@@ -25,6 +25,7 @@ newPlot id =
   , roughDrawCommands: pure unit
   , queue: initialJobQueue
   , status: Robust
+  , name: "Plot " <> (show id)
   }
 
 updateExpressionPlotCommands :: DrawCommand Unit -> ExpressionPlot -> ExpressionPlot

--- a/src/Components/Main/Main.purs
+++ b/src/Components/Main/Main.purs
@@ -1,7 +1,6 @@
 module Components.Main where
 
 import Prelude
-
 import Components.AccuracyInput (accuracyInputComponent)
 import Components.BatchInput (batchInputComponent)
 import Components.BoundsInput (initialBounds, boundsInputComponent)
@@ -89,7 +88,7 @@ mainComponent =
                             [ HP.class_ (ClassName "card-header") ]
                             [ HH.ul
                                 [ HP.class_ (ClassName "nav nav-tabs card-header-tabs") ]
-                                (map (toTab ( 1 < length state.plots) state.selectedPlotId) state.plots)
+                                (map (toTab (1 < length state.plots) state.selectedPlotId) state.plots)
                             ]
                         , HH.div
                             [ HP.class_ (ClassName "card-body") ]
@@ -108,8 +107,6 @@ mainComponent =
                                 ]
                             ]
                         ]
-                    , HH.br_
-                    , HH.slot _boundsInput 1 boundsInputComponent state.bounds (Just <<< HandleBoundsInput)
                     , HH.br_
                     , HH.div
                         [ HP.class_ (ClassName "card") ]
@@ -131,31 +128,41 @@ mainComponent =
                         [ HH.div
                             [ HP.class_ (ClassName "card-header") ]
                             [ HH.div
-                                [ HP.class_ (ClassName "btn-group pr-1") ]
-                                [ HH.button
-                                    [ HP.class_ (ClassName "btn btn-info"), HE.onClick $ toActionEvent $ Pan Left ]
-                                    [ HH.text "◄" ]
-                                , HH.button
-                                    [ HP.class_ (ClassName "btn btn-info"), HE.onClick $ toActionEvent $ Pan Right ]
-                                    [ HH.text "►" ]
-                                ]
-                            , HH.div
-                                [ HP.class_ (ClassName "btn-group pr-1") ]
-                                [ HH.button
-                                    [ HP.class_ (ClassName "btn btn-info"), HE.onClick $ toActionEvent $ Pan Down ]
-                                    [ HH.text "▼" ]
-                                , HH.button
-                                    [ HP.class_ (ClassName "btn btn-info"), HE.onClick $ toActionEvent $ Pan Up ]
-                                    [ HH.text "▲" ]
-                                ]
-                            , HH.div
-                                [ HP.class_ (ClassName "btn-group") ]
-                                [ HH.button
-                                    [ HP.class_ (ClassName "btn btn-info"), HE.onClick $ toActionEvent $ Zoom true ]
-                                    [ HH.text "+" ]
-                                , HH.button
-                                    [ HP.class_ (ClassName "btn btn-info"), HE.onClick $ toActionEvent $ Zoom false ]
-                                    [ HH.text "-" ]
+                                [ HP.class_ (ClassName "row") ]
+                                [ HH.div
+                                    [ HP.class_ (ClassName "pr-2") ]
+                                    [ HH.div
+                                        [ HP.class_ (ClassName "btn-group pr-1") ]
+                                        [ HH.button
+                                            [ HP.class_ (ClassName "btn btn-info"), HE.onClick $ toActionEvent $ Pan Left ]
+                                            [ HH.text "◄" ]
+                                        , HH.button
+                                            [ HP.class_ (ClassName "btn btn-info"), HE.onClick $ toActionEvent $ Pan Right ]
+                                            [ HH.text "►" ]
+                                        ]
+                                    , HH.div
+                                        [ HP.class_ (ClassName "btn-group pr-1") ]
+                                        [ HH.button
+                                            [ HP.class_ (ClassName "btn btn-info"), HE.onClick $ toActionEvent $ Pan Down ]
+                                            [ HH.text "▼" ]
+                                        , HH.button
+                                            [ HP.class_ (ClassName "btn btn-info"), HE.onClick $ toActionEvent $ Pan Up ]
+                                            [ HH.text "▲" ]
+                                        ]
+                                    , HH.div
+                                        [ HP.class_ (ClassName "btn-group") ]
+                                        [ HH.button
+                                            [ HP.class_ (ClassName "btn btn-info"), HE.onClick $ toActionEvent $ Zoom true ]
+                                            [ HH.text "+" ]
+                                        , HH.button
+                                            [ HP.class_ (ClassName "btn btn-info"), HE.onClick $ toActionEvent $ Zoom false ]
+                                            [ HH.text "-" ]
+                                        ]
+                                    ]
+                                , HH.div
+                                    [ HP.class_ (ClassName "") ]
+                                    [ HH.slot _boundsInput 1 boundsInputComponent state.bounds (Just <<< HandleBoundsInput)
+                                    ]
                                 ]
                             ]
                         , HH.div

--- a/src/Components/Main/Main.purs
+++ b/src/Components/Main/Main.purs
@@ -99,7 +99,7 @@ mainComponent =
                             [ HH.div
                                 [ HP.class_ (ClassName "btn-group") ]
                                 [ HH.button
-                                    [ HP.class_ (ClassName "btn btn-success"), HE.onClick $ toActionEvent $ AddPlot ]
+                                    [ HP.class_ (ClassName "btn btn-primary"), HE.onClick $ toActionEvent $ AddPlot ]
                                     [ HH.text "Add plot" ]
                                 , HH.button
                                     [ HP.class_ (ClassName "btn btn-danger"), HE.onClick $ toActionEvent Clear ]
@@ -134,28 +134,28 @@ mainComponent =
                                     [ HH.div
                                         [ HP.class_ (ClassName "btn-group pr-1") ]
                                         [ HH.button
-                                            [ HP.class_ (ClassName "btn btn-info"), HE.onClick $ toActionEvent $ Pan Left ]
+                                            [ HP.class_ (ClassName "btn btn-primary"), HE.onClick $ toActionEvent $ Pan Left ]
                                             [ HH.text "◄" ]
                                         , HH.button
-                                            [ HP.class_ (ClassName "btn btn-info"), HE.onClick $ toActionEvent $ Pan Right ]
+                                            [ HP.class_ (ClassName "btn btn-primary"), HE.onClick $ toActionEvent $ Pan Right ]
                                             [ HH.text "►" ]
                                         ]
                                     , HH.div
                                         [ HP.class_ (ClassName "btn-group pr-1") ]
                                         [ HH.button
-                                            [ HP.class_ (ClassName "btn btn-info"), HE.onClick $ toActionEvent $ Pan Down ]
+                                            [ HP.class_ (ClassName "btn btn-primary"), HE.onClick $ toActionEvent $ Pan Down ]
                                             [ HH.text "▼" ]
                                         , HH.button
-                                            [ HP.class_ (ClassName "btn btn-info"), HE.onClick $ toActionEvent $ Pan Up ]
+                                            [ HP.class_ (ClassName "btn btn-primary"), HE.onClick $ toActionEvent $ Pan Up ]
                                             [ HH.text "▲" ]
                                         ]
                                     , HH.div
                                         [ HP.class_ (ClassName "btn-group") ]
                                         [ HH.button
-                                            [ HP.class_ (ClassName "btn btn-info"), HE.onClick $ toActionEvent $ Zoom true ]
+                                            [ HP.class_ (ClassName "btn btn-primary"), HE.onClick $ toActionEvent $ Zoom true ]
                                             [ HH.text "+" ]
                                         , HH.button
-                                            [ HP.class_ (ClassName "btn btn-info"), HE.onClick $ toActionEvent $ Zoom false ]
+                                            [ HP.class_ (ClassName "btn btn-primary"), HE.onClick $ toActionEvent $ Zoom false ]
                                             [ HH.text "-" ]
                                         ]
                                     ]

--- a/src/Components/Main/Types.purs
+++ b/src/Components/Main/Types.purs
@@ -5,11 +5,9 @@ import Components.AccuracyInput (AccuracyInputSlot)
 import Components.BatchInput (BatchInputSlot)
 import Components.BoundsInput (BoundsInputSlot)
 import Components.Canvas (CanvasSlot, Input)
-import Components.ExpressionInput (ExpressionInputSlot, Status)
-import Data.Maybe (Maybe)
+import Components.ExpressionManager (ExpressionManagerSlot)
+import Components.ExpressionManager.Types (ExpressionPlot)
 import Draw.Commands (DrawCommand)
-import Expression.Syntax (Expression)
-import Plot.JobBatcher (JobQueue)
 import Types (XYBounds)
 
 type State
@@ -19,24 +17,11 @@ type State
     , clearPlot :: DrawCommand Unit
     , batchCount :: Int
     , accuracy :: Number
-    , selectedPlotId :: Int
-    , nextPlotId :: Int
-    , editingSelected :: Boolean
-    }
-
-type ExpressionPlot
-  = { expression :: Maybe Expression
-    , expressionText :: String
-    , robustDrawCommands :: DrawCommand Unit
-    , roughDrawCommands :: DrawCommand Unit
-    , id :: Int
-    , queue :: JobQueue
-    , status :: Status
     }
 
 type ChildSlots
   = ( canvas :: CanvasSlot Int
-    , expressionInput :: ExpressionInputSlot Int
+    , expressionManager :: ExpressionManagerSlot Int
     , boundsInput :: BoundsInputSlot Int
     , batchInput :: BatchInputSlot Int
     , accuracyInput :: AccuracyInputSlot Int

--- a/src/Components/Main/Types.purs
+++ b/src/Components/Main/Types.purs
@@ -21,6 +21,7 @@ type State
     , accuracy :: Number
     , selectedPlotId :: Int
     , nextPlotId :: Int
+    , editingSelected :: Boolean
     }
 
 type ExpressionPlot


### PR DESCRIPTION
# Issues
closes #90
closes #87  

# Summary of changes
- Moved bounds input into the header of the card containing the canvas
- Removed the update bounds button
- Added `onFocusLost` to all the bounds so that the bounds are updated when the user leaves the input.
- Added `oldBounds` to the `BoundsInput` component's state to store the current bounds. The bounds are only updated if the new bounds are different to the current bounds. 
- Added edit button to the expression tabs to allow the user to edit the name of an expression plot
- Added `Components.ExpressionManager` to encapsulate the behaviour of managing which expression tab is selected and the temporary name of the expression name being edited.

# Tests
NA