### PR TITLE
Fixed canvas scrolling and size ratio

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,14 @@
     .small-input {
       max-width: 80px
     }
+
+    .sidebar {
+      min-width: 520px;
+    }
+
+    .canvasCol {
+      min-width: 870px;
+    }
   </style>
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css"
     integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">

--- a/src/Components/BoundsInput/BoundsInput.purs
+++ b/src/Components/BoundsInput/BoundsInput.purs
@@ -1,7 +1,6 @@
 module Components.BoundsInput where
 
 import Prelude
-
 import Components.Common.Action (onClickActionEvent, onEnterPressActionEvent, onFocusOutActionEvent, onValueChangeActionEvent)
 import Components.Common.ClassName (className)
 import Control.Lazy (fix)
@@ -12,10 +11,10 @@ import Expression.Parser (P, literal)
 import Halogen as H
 import Halogen.HTML as HH
 import Halogen.HTML.Properties as HP
-import IntervalArith.Misc (Rational, rationalToNumber)
+import IntervalArith.Misc (Rational, rationalToNumber, toRational)
 import Text.Parsing.Parser (runParser)
 import Text.Parsing.Parser.Expr (buildExprParser)
-import Types (XYBounds)
+import Types (XYBounds, Size)
 
 type BoundsInputSlot p
   = forall q. H.Slot q BoundsInputMessage p
@@ -149,7 +148,7 @@ handleAction = case _ of
   HandleInput YUpper stringInput -> H.modify_ _ { yBounds { upper = stringInput } }
   ResetBounds -> do
     H.modify_ _ { error = Nothing }
-    H.raise (UpdatedBoundsInput initialBounds)
+    H.raise (UpdatedBoundsInput unitBounds)
   Recieve bounds ->
     H.modify_
       _
@@ -197,8 +196,13 @@ parse input = case runParser input expressionParser of
 expressionParser :: P Rational
 expressionParser = fix (\p -> buildExprParser [] literal)
 
-initialBounds :: XYBounds
-initialBounds = xyBounds (-one) one (-one) one
+unitBounds :: XYBounds
+unitBounds = xyBounds (-one) one (-one) one
 
 xyBounds :: Rational -> Rational -> Rational -> Rational -> XYBounds
 xyBounds xLower xUpper yLower yUpper = { xBounds: { upper: xUpper, lower: xLower }, yBounds: { upper: yUpper, lower: yLower } }
+
+canvasSizeToBounds :: Size -> XYBounds
+canvasSizeToBounds size = xyBounds (-ratio) ratio (-one) one
+  where
+  ratio = size.width / size.height

--- a/src/Components/BoundsInput/BoundsInput.purs
+++ b/src/Components/BoundsInput/BoundsInput.purs
@@ -11,7 +11,7 @@ import Expression.Parser (P, literal)
 import Halogen as H
 import Halogen.HTML as HH
 import Halogen.HTML.Properties as HP
-import IntervalArith.Misc (Rational, rationalToNumber, toRational)
+import IntervalArith.Misc (Rational, rationalToNumber)
 import Text.Parsing.Parser (runParser)
 import Text.Parsing.Parser.Expr (buildExprParser)
 import Types (XYBounds, Size)

--- a/src/Components/BoundsInput/BoundsInput.purs
+++ b/src/Components/BoundsInput/BoundsInput.purs
@@ -40,12 +40,13 @@ data Bound
 
 data BoundsInputMessage
   = UpdatedBoundsInput XYBounds
+  | ResetBounds
 
 data Action
   = Recieve XYBounds
   | HandleInput Bound String
   | Update
-  | ResetBounds
+  | Reset
 
 boundsInputComponent :: forall query m. MonadEffect m => H.Component HH.HTML query XYBounds BoundsInputMessage m
 boundsInputComponent =
@@ -123,7 +124,7 @@ render state =
               [ className "btn-group" ]
               [ HH.button
                   [ className "btn btn-warning"
-                  , onClickActionEvent $ ResetBounds
+                  , onClickActionEvent $ Reset
                   ]
                   [ HH.text "Reset bounds" ]
               ]
@@ -146,9 +147,9 @@ handleAction = case _ of
   HandleInput XUpper stringInput -> H.modify_ _ { xBounds { upper = stringInput } }
   HandleInput YLower stringInput -> H.modify_ _ { yBounds { lower = stringInput } }
   HandleInput YUpper stringInput -> H.modify_ _ { yBounds { upper = stringInput } }
-  ResetBounds -> do
+  Reset -> do
     H.modify_ _ { error = Nothing }
-    H.raise (UpdatedBoundsInput unitBounds)
+    H.raise ResetBounds
   Recieve bounds ->
     H.modify_
       _

--- a/src/Components/Canvas/Canvas.purs
+++ b/src/Components/Canvas/Canvas.purs
@@ -136,3 +136,9 @@ calculateNewCanvasSize = do
 
     newHeight = (newWidth * 5.0) / 8.0
   pure $ { width: toRational (round newWidth), height: toRational (round newHeight) }
+
+defaultCanvasSize :: Size
+defaultCanvasSize =
+  { width: toRational 800
+  , height: toRational 500
+  }

--- a/src/Components/Canvas/Canvas.purs
+++ b/src/Components/Canvas/Canvas.purs
@@ -107,7 +107,7 @@ handleAction controller = case _ of
     _ <-
       for state.context \context -> do
         when (state.input.size /= input.size) do
-          context' <- H.liftEffect $ controller.onResize input.size context
+          context' <- H.liftEffect $ controller.resize input.size context
           H.modify_ _ { context = Just context' }
         H.liftEffect $ controller.render context input.operations
     pure unit
@@ -127,7 +127,7 @@ handleAction controller = case _ of
     where
     changeInY = WE.deltaY event
 
-calculateNewCanvasSize :: Effect (Maybe Size)
+calculateNewCanvasSize :: Effect Size
 calculateNewCanvasSize = do
   container <- findElementById "canvasContainer"
   containerWidth <- offsetWidth container
@@ -135,4 +135,4 @@ calculateNewCanvasSize = do
     newWidth = containerWidth - 40.0 -- Account for padding
 
     newHeight = (newWidth * 5.0) / 8.0
-  pure $ Just { width: toRational (round newWidth), height: toRational (round newHeight) }
+  pure $ { width: toRational (round newWidth), height: toRational (round newHeight) }

--- a/src/Components/Canvas/Canvas.purs
+++ b/src/Components/Canvas/Canvas.purs
@@ -1,8 +1,10 @@
 module Components.Canvas where
 
 import Prelude
+
 import Components.Canvas.Context (DrawContext)
 import Components.Canvas.Controller (CanvasController)
+import Components.Common.HTML (findElementById)
 import Control.Monad.Maybe.Trans (MaybeT(..), runMaybeT)
 import Control.Monad.Maybe.Trans as MaybeT
 import Data.Int (round)
@@ -19,13 +21,13 @@ import Halogen.HTML.Properties as HP
 import Halogen.Query.EventSource as ES
 import IntervalArith.Misc (rationalToNumber, toRational)
 import Types (Delta, Size)
+import Web.Event.Event as E
 import Web.HTML.HTMLElement (offsetWidth, toEventTarget)
 import Web.UIEvent.MouseEvent (MouseEvent)
 import Web.UIEvent.MouseEvent as ME
 import Web.UIEvent.WheelEvent (WheelEvent)
 import Web.UIEvent.WheelEvent as WE
 import Web.UIEvent.WheelEvent.EventTypes as WET
-import Components.Common.HTML (findElementById)
 
 type CanvasSlot p
   = forall q. H.Slot q CanvasMessage p
@@ -123,6 +125,7 @@ handleAction controller = case _ of
       H.raise $ Dragged { x: state.oldDelta.x - delta.x, y: delta.y - state.oldDelta.y }
   Scroll event ->
     when (changeInY /= 0.0) do
+      H.liftEffect $ E.preventDefault (WE.toEvent event)
       H.raise $ Scrolled (changeInY < 0.0)
     where
     changeInY = WE.deltaY event

--- a/src/Components/Canvas/Controller.purs
+++ b/src/Components/Canvas/Controller.purs
@@ -16,11 +16,11 @@ import Types (Size)
 type CanvasController commands
   = { init :: Size -> Effect (Maybe DrawContext)
     , render :: DrawContext -> commands -> Effect Unit
-    , onResize :: Size -> DrawContext -> Effect DrawContext
+    , resize :: Size -> DrawContext -> Effect DrawContext
     }
 
 canvasController :: CanvasController (DrawCommand Unit)
-canvasController = { init, render, onResize }
+canvasController = { init, render, resize }
   where
   init :: Size -> Effect (Maybe DrawContext)
   init size = do
@@ -37,5 +37,5 @@ canvasController = { init, render, onResize }
   render :: DrawContext -> DrawCommand Unit -> Effect Unit
   render = runDrawCommands
 
-  onResize :: Size -> DrawContext -> Effect DrawContext
-  onResize size ctx = pure $ ctx { canvasWidth = rationalToNumber size.width, canvasHeight = rationalToNumber size.height }
+  resize :: Size -> DrawContext -> Effect DrawContext
+  resize size ctx = pure $ ctx { canvasWidth = rationalToNumber size.width, canvasHeight = rationalToNumber size.height }

--- a/src/Components/Common/HTML.purs
+++ b/src/Components/Common/HTML.purs
@@ -1,0 +1,25 @@
+module Components.Common.HTML where
+
+import Prelude
+import Data.Maybe (Maybe(..))
+import Effect (Effect)
+import Effect.Exception.Unsafe (unsafeThrow)
+import Web.DOM.NonElementParentNode (getElementById)
+import Web.HTML (window) as Web
+import Web.HTML.HTMLDocument (toNonElementParentNode, HTMLDocument)
+import Web.HTML.HTMLElement (HTMLElement, fromElement)
+import Web.HTML.Window (document) as Web
+
+findElementById :: String -> Effect HTMLElement
+findElementById id = do
+  document <- Web.document =<< Web.window
+  findElementInDocumentById id document
+
+findElementInDocumentById :: String -> HTMLDocument -> Effect HTMLElement
+findElementInDocumentById id document = do
+  maybeElement <- getElementById id $ toNonElementParentNode document
+  case maybeElement of
+    Nothing -> pure $ unsafeThrow $ "Cannot find element '" <> id <> "' in document"
+    Just maybeHTMLElement -> case fromElement maybeHTMLElement of
+      Nothing -> pure $ unsafeThrow $ "Cannot convert element '" <> id <> "' to HTMLElement"
+      Just element -> pure $ element

--- a/src/Components/Main/Action.purs
+++ b/src/Components/Main/Action.purs
@@ -79,11 +79,8 @@ handleJobResult (Just jobResult) newState =
 
 resizeCanvas :: forall output. HalogenMain output Unit
 resizeCanvas = do
-  maybeNewCanvasSize <- H.liftEffect calculateNewCanvasSize
-  case maybeNewCanvasSize of
-    Nothing -> pure unit
-    Just newCanvasSize -> do
-      H.modify_ (_ { input { size = newCanvasSize } })
+  newCanvasSize <- H.liftEffect calculateNewCanvasSize
+  H.modify_ (_ { input { size = newCanvasSize } })
 
 initialiseAction :: forall output. State -> HalogenMain output Unit
 initialiseAction state = do

--- a/src/Components/Main/Action.purs
+++ b/src/Components/Main/Action.purs
@@ -48,7 +48,7 @@ handleAction action = do
   state <- H.get
   case action of
     HandleExpressionManager message -> handleExpressionPlotMessage state message
-    HandleBoundsInput (UpdatedBoundsInput newBounds) -> redrawWithBounds state newBounds
+    HandleBoundsInput message -> handleBoundsInputMessage state message
     Pan direction -> redrawWithDelayAndBounds state (panBounds state.bounds direction)
     Zoom isZoomIn -> redrawWithDelayAndBounds state (zoomBounds state.bounds isZoomIn)
     HandleCanvas message -> handleCanvasMessage state message
@@ -89,6 +89,11 @@ initialiseAction = do
   resizeCanvas
   state <- H.get
   clearAction state
+
+handleBoundsInputMessage :: forall output. State -> BoundsInputMessage -> HalogenMain output Unit
+handleBoundsInputMessage state (UpdatedBoundsInput newBounds) = redrawWithBounds state newBounds
+
+handleBoundsInputMessage state ResetBounds = redrawWithBounds state $ canvasSizeToBounds state.input.size
 
 clearAction :: forall output. State -> HalogenMain output Unit
 clearAction state = do

--- a/src/Components/Main/Main.purs
+++ b/src/Components/Main/Main.purs
@@ -1,7 +1,6 @@
 module Components.Main where
 
 import Prelude
-
 import Components.BatchInput (batchInputComponent)
 import Components.BoundsInput (boundsInputComponent, canvasSizeToBounds)
 import Components.Canvas (canvasComponent, defaultCanvasSize)
@@ -22,7 +21,6 @@ import Effect.Class (class MonadEffect)
 import Halogen as H
 import Halogen.HTML as HH
 import Halogen.HTML.Properties as HP
-
 import Types (Direction(..))
 
 _canvas = SProxy :: SProxy "canvas"
@@ -72,7 +70,7 @@ mainComponent =
             [ HH.div
                 [ className "row" ]
                 [ HH.div
-                    [ className "col-md-4" ]
+                    [ className "col-xl-3 col-md-12 sidebar" ]
                     [ HH.slot _expressionManager 1 expressionManagerComponent (toExpressionManagerInput state) (Just <<< HandleExpressionManager)
                     , HH.br_
                     , HH.div
@@ -86,15 +84,16 @@ mainComponent =
                             [ HH.slot _batchInput 1 batchInputComponent state.batchCount (Just <<< HandleBatchInput)
                             ]
                         ]
+                    , HH.br_
                     ]
                 , HH.div
-                    [ className "col-md-8" ]
+                    [ className "col-xl col-md-12 canvasCol" ]
                     [ HH.div
                         [ className "card" ]
                         [ HH.div
                             [ className "card-header" ]
                             [ HH.div
-                                [ className "row" ]
+                                [ className "form-inline" ]
                                 [ HH.div
                                     [ className "pr-2" ]
                                     [ HH.div
@@ -137,10 +136,7 @@ mainComponent =
                                             [ HH.text "-" ]
                                         ]
                                     ]
-                                , HH.div
-                                    []
-                                    [ HH.slot _boundsInput 1 boundsInputComponent state.bounds (Just <<< HandleBoundsInput)
-                                    ]
+                                , HH.slot _boundsInput 1 boundsInputComponent state.bounds (Just <<< HandleBoundsInput)
                                 ]
                             ]
                         , HH.div

--- a/src/Components/Main/Main.purs
+++ b/src/Components/Main/Main.purs
@@ -16,6 +16,7 @@ import Control.Monad.Reader (ReaderT)
 import Data.Maybe (Maybe(..))
 import Data.Symbol (SProxy(..))
 import Effect.Aff (Aff)
+import Effect.Aff.Class (class MonadAff)
 import Effect.Class (class MonadEffect)
 import Halogen as H
 import Halogen.HTML as HH
@@ -63,7 +64,7 @@ mainComponent =
     , autoRobust: false
     }
 
-  render :: forall m. MonadEffect m => State -> H.ComponentHTML Action ChildSlots m
+  render :: forall m. MonadAff m => MonadEffect m => State -> H.ComponentHTML Action ChildSlots m
   render state =
     HH.div_
       $ [ HH.h1_

--- a/src/Components/Main/Main.purs
+++ b/src/Components/Main/Main.purs
@@ -1,9 +1,10 @@
 module Components.Main where
 
 import Prelude
+
 import Components.BatchInput (batchInputComponent)
-import Components.BoundsInput (initialBounds, boundsInputComponent)
-import Components.Canvas (canvasComponent)
+import Components.BoundsInput (boundsInputComponent, canvasSizeToBounds)
+import Components.Canvas (canvasComponent, defaultCanvasSize)
 import Components.Canvas.Controller (canvasController)
 import Components.Common.Action (onClickActionEvent)
 import Components.Common.ClassName (className)
@@ -21,7 +22,7 @@ import Effect.Class (class MonadEffect)
 import Halogen as H
 import Halogen.HTML as HH
 import Halogen.HTML.Properties as HP
-import IntervalArith.Misc (toRational)
+
 import Types (Direction(..))
 
 _canvas = SProxy :: SProxy "canvas"
@@ -50,12 +51,9 @@ mainComponent =
     { input:
         { operations: pure unit
         , canvasId: canvasId
-        , size:
-            { width: toRational 800
-            , height: toRational 500
-            }
+        , size: defaultCanvasSize
         }
-    , bounds: initialBounds
+    , bounds: canvasSizeToBounds defaultCanvasSize
     , plots:
         [ newPlot 0
         ]

--- a/test/Plot/JobBatcher/CancelAll.purs
+++ b/test/Plot/JobBatcher/CancelAll.purs
@@ -4,7 +4,7 @@ module Test.Plot.JobBatcher.CancelAll
 
 import Prelude
 
-import Components.BoundsInput (initialBounds)
+import Components.BoundsInput (unitBounds)
 import Data.Foldable (class Foldable, foldl)
 import Data.Maybe (Maybe(..), isNothing)
 import Data.Set (fromFoldable)
@@ -53,7 +53,7 @@ cancelAllTests =
 basicJob :: Id -> Job
 basicJob id =
   { id
-  , command: Empty initialBounds
+  , command: Empty unitBounds
   , batchId: 0
   }
 

--- a/test/Plot/JobBatcher/HasJobs.purs
+++ b/test/Plot/JobBatcher/HasJobs.purs
@@ -4,7 +4,7 @@ module Test.Plot.JobBatcher.HasJobs
 
 import Prelude
 
-import Components.BoundsInput (initialBounds)
+import Components.BoundsInput (unitBounds)
 import Misc.Queue (push)
 import Plot.Commands (PlotCommand(..))
 import Plot.JobBatcher (Job, hasJobs, initialJobQueue)
@@ -28,6 +28,6 @@ hasJobsTests =
 basicJob :: Job
 basicJob =
   { id: 0
-  , command: Empty initialBounds
+  , command: Empty unitBounds
   , batchId: 0
   }

--- a/test/Plot/JobBatcher/SetRunning.purs
+++ b/test/Plot/JobBatcher/SetRunning.purs
@@ -4,7 +4,7 @@ module Test.Plot.JobBatcher.SetRunning
 
 import Prelude
 
-import Components.BoundsInput (initialBounds)
+import Components.BoundsInput (unitBounds)
 import Data.Foldable (class Foldable, foldl)
 import Data.Maybe (Maybe(..))
 import Misc.Queue (Queue, push)
@@ -41,7 +41,7 @@ setRunningTests =
 basicJob :: Id -> Job
 basicJob id =
   { id
-  , command: Empty initialBounds
+  , command: Empty unitBounds
   , batchId: 0
   }
 


### PR DESCRIPTION
# Issues
closes #56
closes #88 

# Summary of changes
- Renamed `initialBounds` to `unitBounds`
- Added `canvasSizeToBounds` to scale the `unitBounds` such that #88 is satisfied
- Changed the scroll event listener target to be the `canvas` instead of the `document`. Scroll zooming will now only work when the mouse is over the canvas.
- Moved `findElementById` into `Components.Common.HTML` as it is a common function.
- Updated `findElementById` so that it will throw an error if the element is not found instead of failing silently
- Renamed `onResize` to `resize` in `Components.Canvas.Controller`
- Removed `Scroll` action from `Components.Main`

# Tests
- Test.Plot.JobBatcher.HasJobs (Updated)
- Test.Plot.JobBatcher.SetRunning (Updated)