### PR TITLE
Added default example functions

### DIFF
--- a/src/Components/Common/Action.purs
+++ b/src/Components/Common/Action.purs
@@ -1,7 +1,6 @@
 module Components.Common.Action where
 
 import Prelude
-
 import Data.Maybe (Maybe(..))
 import Halogen.HTML (IProp)
 import Halogen.HTML.Events as HE
@@ -14,10 +13,10 @@ import Web.UIEvent.MouseEvent (MouseEvent)
 toActionEvent :: forall action event. action -> event -> Maybe action
 toActionEvent action = const $ Just action
 
--- | A helper function to map the specified `const` action to an `onValueChange` event handler 
--- | function for a Halogen element.
-toValueChangeActionEvent :: forall action. (String -> action) -> String -> Maybe action
-toValueChangeActionEvent action value = Just $ action value
+-- | A helper function to map the specified `const` action to an event handler 
+-- | function that take some event data for a Halogen element.
+toActionEventWithData :: forall action eventData. (eventData -> action) -> eventData -> Maybe action
+toActionEventWithData action value = Just $ action value
 
 -- | A helper function to map the specified `const` action to an `onChecked` event handler function 
 -- | for a Halogen element. This helper function will ignore the event when the element is unchecked. 
@@ -34,9 +33,9 @@ onClickActionEvent action = HE.onClick $ toActionEvent action
 onFocusOutActionEvent :: forall action r. action -> IProp ( onFocusOut :: FocusEvent | r ) action
 onFocusOutActionEvent action = HE.onFocusOut $ toActionEvent action
 
--- | Wrapper for the `onValueChange` event handler that will map the event to the specified `const` action.
+-- | Wrapper for the `onValueChange` event handler that will map the event to the specified action.
 onValueChangeActionEvent :: forall action r. (String -> action) -> IProp ( onChange :: Event, value :: String | r ) action
-onValueChangeActionEvent action = HE.onValueChange $ toValueChangeActionEvent action
+onValueChangeActionEvent action = HE.onValueChange $ toActionEventWithData action
 
 -- | Wrapper for the `onChecked` event handler that will map the event to the specified `const` action. This 
 -- | event handler will ignore the event when the element is unchecked.
@@ -46,3 +45,7 @@ onCheckedActionEvent action = HE.onChecked $ toCheckedEvent action
 -- | Wrapper for the `onKeyUp` event handler that will map the event to the specified `const` action if the key pressed is `Enter`.
 onEnterPressActionEvent :: forall action r. action -> IProp ( onKeyUp :: KeyboardEvent | r ) action
 onEnterPressActionEvent action = HE.onKeyUp $ \event -> if code event == "Enter" then Just action else Nothing
+
+-- | Wrapper for the `onSelectedIndexChange` event handler that will map the event to the specified action.
+onSelectedIndexChangeActionEvent :: forall action r. (Int -> action) -> IProp ( onChange :: Event, selectedIndex :: Int | r ) action
+onSelectedIndexChangeActionEvent action = HE.onSelectedIndexChange $ toActionEventWithData action

--- a/src/Components/ExpressionManager/ExpressionManager.purs
+++ b/src/Components/ExpressionManager/ExpressionManager.purs
@@ -1,6 +1,7 @@
 module Components.ExpressionManager where
 
 import Prelude
+
 import Components.Checkbox (CheckboxMessage(..), checkboxComponent)
 import Components.Common.Action (onClickActionEvent, onEnterPressActionEvent, onFocusOutActionEvent, onValueChangeActionEvent)
 import Components.Common.ClassName (appendClassNameIf, className, classNameIf)
@@ -11,8 +12,11 @@ import Data.Array (catMaybes, find, head, length)
 import Data.Maybe (Maybe(..), fromMaybe, isJust)
 import Data.Symbol (SProxy(..))
 import Effect.Class (class MonadEffect)
+import Halogen (PropName(..))
 import Halogen as H
+import Halogen.HTML (prop)
 import Halogen.HTML as HH
+import Halogen.HTML.Properties (ButtonType(..))
 import Halogen.HTML.Properties as HP
 import Halogen.HTML.Properties.ARIA as HA
 
@@ -97,7 +101,24 @@ render state =
         [ className "card" ]
         [ HH.div
             [ className "card-header" ]
-            [ HH.ul
+            [ HH.div
+                [ className "input-group mb-3" ]
+                [ HH.div
+                    [ className "input-group-prepend" ]
+                    [ HH.span
+                        [ className "input-group-text" ]
+                        [ HH.text "Add example:" ]
+                    ]
+                , HH.select
+                    [ HP.id_ "batchCount"
+                    , className "form-control"
+                    , HP.selectedIndex 0
+                    ]
+                    [ HH.option_ [ HH.text "" ]
+                    , HH.option_ [ HH.text "x*sin(1/(x^2))" ]
+                    ]
+                ]
+            , HH.ul
                 [ className "nav nav-tabs card-header-tabs" ]
                 ((map (toTab state) state.plots) <> [ addPlotTab ])
             ]

--- a/src/Components/ExpressionManager/ExpressionManager.purs
+++ b/src/Components/ExpressionManager/ExpressionManager.purs
@@ -1,7 +1,6 @@
 module Components.ExpressionManager where
 
 import Prelude
-
 import Components.Checkbox (CheckboxMessage(..), checkboxComponent)
 import Components.Common.Action (onClickActionEvent, onEnterPressActionEvent, onFocusOutActionEvent, onSelectedIndexChangeActionEvent, onValueChangeActionEvent)
 import Components.Common.ClassName (appendClassNameIf, className, classNameIf)

--- a/src/Components/ExpressionManager/ExpressionManager.purs
+++ b/src/Components/ExpressionManager/ExpressionManager.purs
@@ -1,9 +1,11 @@
 module Components.ExpressionManager where
 
 import Prelude
+
 import Components.Checkbox (CheckboxMessage(..), checkboxComponent)
 import Components.Common.Action (onClickActionEvent, onEnterPressActionEvent, onFocusOutActionEvent, onSelectedIndexChangeActionEvent, onValueChangeActionEvent)
 import Components.Common.ClassName (appendClassNameIf, className, classNameIf)
+import Components.Common.Properties (style)
 import Components.ExpressionInput (ExpressionInputMessage(..), expressionInputComponent, parseAndCheckExpression)
 import Components.ExpressionInput.Controller (expressionInputController)
 import Components.ExpressionManager.Types (ExpressionPlot, ChildSlots)
@@ -99,23 +101,7 @@ render state =
         [ className "card" ]
         [ HH.div
             [ className "card-header" ]
-            [ HH.div
-                [ className "input-group mb-3" ]
-                [ HH.div
-                    [ className "input-group-prepend" ]
-                    [ HH.span
-                        [ className "input-group-text" ]
-                        [ HH.text "Add example:" ]
-                    ]
-                , HH.select
-                    [ HP.id_ "batchCount"
-                    , className "form-control"
-                    , HP.selectedIndex 0
-                    , onSelectedIndexChangeActionEvent SelectedExample
-                    ]
-                    exampleFunctionOptions
-                ]
-            , HH.ul
+            [ HH.ul
                 [ className "nav nav-tabs card-header-tabs" ]
                 ((map (toTab state) state.plots) <> [ addPlotTab ])
             ]
@@ -210,10 +196,12 @@ overwriteWithExample id example = case parseAndCheckExpression expressionInputCo
 examples :: Array String
 examples =
   [ "x*sin(1/(x^2))"
+  , "sin(100*x)"
+  , "(1+x^2)^(sin(10*x))-1"
   ]
 
 exampleFunctionOptions :: forall w. Array (HH.HTML w Action)
-exampleFunctionOptions = map toOption $ [ "" ] <> examples
+exampleFunctionOptions = [ HH.option [ HP.disabled true, HP.selected true ] [ HH.text "Add example function from below" ] ] <> map toOption examples
   where
   toOption :: String -> HH.HTML w Action
   toOption text = HH.option_ [ HH.text text ]
@@ -265,10 +253,17 @@ addPlotTab =
         [ HH.div
             [ className "form-inline" ]
             [ HH.button
-                [ className "btn-success btn-sm"
+                [ className "btn btn-success btn-sm"
                 , onClickActionEvent Add
                 ]
                 [ HH.text "+" ]
+            , HH.select
+                [ className "form-control form-control-sm"
+                , style "max-width: 20px"
+                , HP.selectedIndex 0
+                , onSelectedIndexChangeActionEvent SelectedExample
+                ]
+                exampleFunctionOptions
             ]
         ]
     ]
@@ -296,7 +291,7 @@ maybeEditButton state plotId =
   if state.selectedPlotId == plotId && not state.editingSelected then
     Just
       $ HH.button
-          [ className "btn-primary btn-sm"
+          [ className "btn btn-primary btn-sm"
           , onClickActionEvent Edit
           ]
           [ HH.text "🖉" ]
@@ -308,7 +303,7 @@ maybeDeleteButton state plotId =
   if 1 < length state.plots then
     Just
       $ HH.button
-          [ className "btn-danger btn-sm"
+          [ className "btn btn-danger btn-sm"
           , onClickActionEvent $ Delete plotId
           ]
           [ HH.text "✕" ]


### PR DESCRIPTION
# Issues
closes #102 

# Summary of changes
- Refactored `toValueChangeActionEvent` into a generic `toActionEventWithData` function
- Added `onSelectedIndexChangeActionEvent` for select inputs
- Pulled the parsing of expressions out of `handleAction` in `Components.ExpressionInput` and into `parseAndCheckExpression` so that it could be reused by the `Components.ExpressionManager`
- Added select field containing example functions. When the user changes the value in the select input it will add it to the expression manager.

# Tests
N/A