### PR TITLE
Fix accuracy issues in sqrt(x^2)

### DIFF
--- a/src/Expression/Evaluate/AutomaticDifferentiator.purs
+++ b/src/Expression/Evaluate/AutomaticDifferentiator.purs
@@ -1,7 +1,6 @@
 module Expression.Evaluate.AutomaticDifferentiator where
 
-import Prelude hiding (min,max)
-
+import Prelude hiding (min, max)
 import Data.Array (head)
 import Data.Maybe (Maybe(..))
 import Data.Tuple (Tuple(..))
@@ -146,19 +145,21 @@ evaluateDerivative2WithSample variableMap sample = evaluate
         pure
           { value: u / v
           , derivative: (u' * v - u * v') / (v ^ 2)
-          , derivative2: u'' / v - (two * u' * v' + u * v'')/(v^2) + two * u * v' ^ 2 / (v ^ 3)
+          , derivative2: u'' / v - (two * u' * v' + u * v'') / (v ^ 2) + two * u * v' ^ 2 / (v ^ 3)
           }
       -- (g^f)' = g^(f-1) * ((f*g')+(g*f'*log(g)))
       -- source: https://www.wolframalpha.com/input/?i=(f%5E(g))%27
       Power
         | isZero v' && isZero v'' -> do
           uPowV <- u `power` v
+          uPowVminus1 <- u `power` (v - one)
+          uPowVminus2 <- u `power` (v - two)
           let
-            t = (v * u') / u
+            t = (v * u')
           pure
             { value: uPowV
-            , derivative: uPowV * t
-            , derivative2: uPowV * (t ^ 2 + (v * u'') / u - v * u' ^ 2 / u ^ 2)
+            , derivative: uPowVminus1 * t
+            , derivative2: uPowVminus2 * (t ^ 2 + (v * u'') * u - v * u' ^ 2)
             }
       Power -> do
         uPowV <- u `power` v

--- a/src/IntervalArith/Approx/Sqrt.purs
+++ b/src/IntervalArith/Approx/Sqrt.purs
@@ -28,11 +28,11 @@ sqrtA :: Approx -> Maybe Approx
 sqrtA Bottom = Just Bottom
 
 sqrtA x@(Approx mb m e _)
-  | m < -e = Nothing -- definitely negative
-  | m == zero && e == zero = Just x
-  | m <= e = map (unionA zero) $ sqrtA (upperA x) -- possibly negative, be optimistic
-  | e > zero = increasingPartialFunctionViaBounds sqrtA x
-  | otherwise = result -- e == zero || e == m
+  | m == zero && e == zero = Just x -- x = zero
+  | m < -e = Nothing -- x definitely negative
+  | m <= e = map (unionA zero) $ sqrtA (upperA x) -- x contains zero, ignore any negative values
+  | e > zero = increasingPartialFunctionViaBounds sqrtA x -- x positive, not exact
+  | otherwise = result -- e == zero, ie x is exact
     where
     k = 2 * mb + 2
 

--- a/src/IntervalArith/Approx/Sqrt.purs
+++ b/src/IntervalArith/Approx/Sqrt.purs
@@ -5,7 +5,6 @@
 module IntervalArith.Approx.Sqrt where
 
 import Prelude
-
 import Data.BigInt as BigInt
 import Data.Int as Int
 import Data.Maybe (Maybe(..))
@@ -30,9 +29,9 @@ sqrtA Bottom = Just Bottom
 
 sqrtA x@(Approx mb m e _)
   | m < -e = Nothing -- definitely negative
-  | m < e = map (unionA zero) $ sqrtA (upperA x) -- possibly negative, be optimistic
+  | m <= e = map (unionA zero) $ sqrtA (upperA x) -- possibly negative, be optimistic
   | m == zero && e == zero = Just x
-  | e > zero && e /= m = increasingPartialFunctionViaBounds sqrtA x
+  | e > zero = increasingPartialFunctionViaBounds sqrtA x
   | otherwise = result -- e == zero || e == m
     where
     k = 2 * mb + 2

--- a/src/IntervalArith/Approx/Sqrt.purs
+++ b/src/IntervalArith/Approx/Sqrt.purs
@@ -29,8 +29,8 @@ sqrtA Bottom = Just Bottom
 
 sqrtA x@(Approx mb m e _)
   | m < -e = Nothing -- definitely negative
-  | m <= e = map (unionA zero) $ sqrtA (upperA x) -- possibly negative, be optimistic
   | m == zero && e == zero = Just x
+  | m <= e = map (unionA zero) $ sqrtA (upperA x) -- possibly negative, be optimistic
   | e > zero = increasingPartialFunctionViaBounds sqrtA x
   | otherwise = result -- e == zero || e == m
     where

--- a/src/Plot/Commands.purs
+++ b/src/Plot/Commands.purs
@@ -8,7 +8,7 @@ import Types (XYBounds)
 data PlotCommand
   = Empty XYBounds
   | RoughPlot XYBounds Expression String
-  | RobustPlot XYBounds Expression (Array (Tuple Depth Approx)) String
+  | RobustPlot XYBounds Expression (Array (Tuple Depth Approx)) Number String
 
 type Depth
   = Int
@@ -24,4 +24,4 @@ isPlotExpression (RoughPlot _ _ _) = true
 
 isPlotExpression (Empty _) = false
 
-isPlotExpression (RobustPlot _ _ _ _) = true
+isPlotExpression (RobustPlot _ _ _ _ _) = true

--- a/src/Plot/Commands.purs
+++ b/src/Plot/Commands.purs
@@ -1,5 +1,6 @@
 module Plot.Commands where
 
+import Data.Tuple (Tuple)
 import Expression.Syntax (Expression)
 import IntervalArith.Approx (Approx)
 import Types (XYBounds)
@@ -7,7 +8,10 @@ import Types (XYBounds)
 data PlotCommand
   = Empty XYBounds
   | RoughPlot XYBounds Expression String
-  | RobustPlot XYBounds Expression (Array Approx) String
+  | RobustPlot XYBounds Expression (Array (Tuple Depth Approx)) String
+
+type Depth
+  = Int
 
 roughPlot :: XYBounds -> Expression -> String -> PlotCommand
 roughPlot = RoughPlot

--- a/src/Plot/JobBatcher.purs
+++ b/src/Plot/JobBatcher.purs
@@ -14,18 +14,18 @@ module Plot.JobBatcher
   ) where
 
 import Prelude
-
 import Data.Array (elem, foldl, foldr)
 import Data.Foldable (class Foldable)
 import Data.Maybe (Maybe(..))
 import Data.Set (Set, empty, insert) as S
+import Data.Tuple (Tuple)
 import Draw.Commands (DrawCommand)
 import Effect.Aff (Aff)
 import Expression.Syntax (Expression)
 import IntervalArith.Approx (Approx)
 import Misc.Array (split)
 import Misc.Queue (Queue, empty, null, peek, push, tail, toList, length) as Q
-import Plot.Commands (PlotCommand(..))
+import Plot.Commands (PlotCommand(..), Depth)
 import Plot.PlotController (computePlotAsync)
 import Plot.RoughPlot (evaluateWithX)
 import Plot.Segments (segmentDomain)
@@ -157,5 +157,5 @@ segmentRobust accuracyTarget batchSegmentCount bounds expression label = command
 
   commands = map toPlotCommand splitDomainSegments
 
-  toPlotCommand :: Array Approx -> PlotCommand
+  toPlotCommand :: Array (Tuple Depth Approx) -> PlotCommand
   toPlotCommand segments = RobustPlot bounds expression segments label

--- a/src/Plot/JobBatcher.purs
+++ b/src/Plot/JobBatcher.purs
@@ -158,4 +158,4 @@ segmentRobust accuracyTarget batchSegmentCount bounds expression label = command
   commands = map toPlotCommand splitDomainSegments
 
   toPlotCommand :: Array (Tuple Depth Approx) -> PlotCommand
-  toPlotCommand segments = RobustPlot bounds expression segments label
+  toPlotCommand segments = RobustPlot bounds expression segments accuracyTarget label

--- a/src/Plot/PlotController.purs
+++ b/src/Plot/PlotController.purs
@@ -24,4 +24,4 @@ runCommand _ (Empty bounds) = clearAndDrawGridLines bounds
 
 runCommand canvasSize (RoughPlot bounds expression label) = drawRoughPlot canvasSize bounds expression label
 
-runCommand canvasSize (RobustPlot bounds expression domainSegments label) = drawRobustPlot canvasSize bounds expression domainSegments label
+runCommand canvasSize (RobustPlot bounds expression domainSegments accuracyTarget label) = drawRobustPlot canvasSize bounds expression domainSegments accuracyTarget label

--- a/src/Plot/RobustPlot.purs
+++ b/src/Plot/RobustPlot.purs
@@ -14,9 +14,10 @@ import Expression.Syntax (Expression)
 import IntervalArith.Approx (Approx, boundsA, boundsNumber, centreA, fromRationalPrec, isFinite, lowerA, toNumber, upperA)
 import IntervalArith.Approx.NumOrder (absA, maxA, (!<=!), (!>=!))
 import IntervalArith.Misc (Rational, rationalToNumber, two)
+import Plot.Commands (Depth)
 import Types (Polygon, Size, XYBounds)
 
-drawRobustPlot :: Size -> XYBounds -> Expression -> Array Approx -> String -> DrawCommand Unit
+drawRobustPlot :: Size -> XYBounds -> Expression -> Array (Tuple Depth Approx) -> String -> DrawCommand Unit
 drawRobustPlot canvasSize bounds expression domainSegments label = drawCommands
   where
   segmentEnclosures = plotEnclosures canvasSize bounds domainSegments evaluateWithX evaluateWithX2
@@ -42,7 +43,7 @@ drawRobustPlot canvasSize bounds expression domainSegments label = drawCommands
 plotEnclosures ::
   Size ->
   XYBounds ->
-  Array Approx ->
+  Array (Tuple Depth Approx) ->
   (Approx -> Maybe (ValueAndDerivative Approx)) ->
   (Approx -> Maybe (ValueAndDerivative2 Approx)) ->
   Array (Maybe Polygon)
@@ -65,7 +66,7 @@ plotEnclosures canvasSize bounds domainSegments evaluator evaluator2 = segmentEn
   toRange :: Rational -> Rational -> Tuple Rational Rational
   toRange lower upper = Tuple lower upper
 
-  toCanvasEnclosure :: Approx -> Maybe Polygon
+  toCanvasEnclosure :: (Tuple Depth Approx) -> Maybe Polygon
   {- overview:
       - try to compute f'(x)
         - if f''(x) is positive or negative, get f'(x) by endpoints
@@ -73,7 +74,7 @@ plotEnclosures canvasSize bounds domainSegments evaluator evaluator2 = segmentEn
       - if f'(x) cannot be computed, use a box with f(x)
       - if f'(x) is available, use it to compute parallelogram and intersect it with the f(x) box
     -}
-  toCanvasEnclosure x =
+  toCanvasEnclosure (Tuple depth x) =
     let
       (Tuple canvasXLower canvasXUpper) = bimap toCanvasX toCanvasX $ boundsNumber x
 

--- a/src/Plot/RobustPlot.purs
+++ b/src/Plot/RobustPlot.purs
@@ -1,7 +1,6 @@
 module Plot.RobustPlot where
 
 import Prelude
-
 import Data.Array (catMaybes, concat, reverse, take)
 import Data.Bifunctor (bimap)
 import Data.Either (Either(..))
@@ -128,7 +127,7 @@ plotEnclosures { canvasSize, bounds, domainSegments, accuracyTarget, evaluator, 
             xGradLeft <- (_.derivative) <$> evaluator xLA
             xGradRight <- (_.derivative) <$> evaluator xUA
             Just (Tuple (lowerA xGradRight) (upperA xGradLeft))
-          | otherwise -> case boundsA <$> (_.derivative) <$> evaluator xMidPoint of
+          | isFinite xGradGradLower && isFinite xGradGradUpper -> case boundsA <$> (_.derivative) <$> evaluator xMidPoint of
             Just (Tuple xGradientMidPointLower xGradientMidPointUpper)
               | isFinite xGradientMidPointLower && isFinite xGradientMidPointUpper ->
                 let

--- a/src/Plot/Segments.purs
+++ b/src/Plot/Segments.purs
@@ -13,7 +13,7 @@ import IntervalArith.Misc (Rational, rationalToNumber, two)
 import Plot.Commands (Depth)
 
 minDepth :: Depth
-minDepth = 5
+minDepth = 3
 
 maxDepth :: Depth
 maxDepth = 10

--- a/src/Plot/Segments.purs
+++ b/src/Plot/Segments.purs
@@ -8,7 +8,7 @@ import Data.Number as Number
 import Data.Ord (abs)
 import Data.Tuple (Tuple(..))
 import Expression.Evaluate.AutomaticDifferentiator (ValueAndDerivative2)
-import IntervalArith.Approx (Approx, fromRationalBoundsPrec)
+import IntervalArith.Approx (Approx, Precision, fromRationalBoundsPrec)
 import IntervalArith.Misc (Rational, rationalToNumber, two)
 import Plot.Commands (Depth)
 
@@ -17,6 +17,9 @@ minDepth = 5
 
 maxDepth :: Depth
 maxDepth = 10
+
+xPrecision :: Precision
+xPrecision = 50
 
 segmentDomain :: Number -> (Number -> Maybe (ValueAndDerivative2 Number)) -> Rational -> Rational -> Array (Tuple Depth Approx)
 segmentDomain accuracyTarget evaluator l u =
@@ -47,7 +50,7 @@ segmentDomain accuracyTarget evaluator l u =
 
   segmentDomainF { depth, xL, evaluatorXL, xU, evaluatorXU } = segments
     where
-    x = fromRationalBoundsPrec 50 xL xU
+    x = fromRationalBoundsPrec xPrecision xL xU
 
     xM = (xL + xU) / two
 

--- a/src/Plot/Segments.purs
+++ b/src/Plot/Segments.purs
@@ -12,6 +12,12 @@ import IntervalArith.Approx (Approx, fromRationalBoundsPrec)
 import IntervalArith.Misc (Rational, rationalToNumber, two)
 import Plot.Commands (Depth)
 
+minDepth :: Depth
+minDepth = 5
+
+maxDepth :: Depth
+maxDepth = 10
+
 segmentDomain :: Number -> (Number -> Maybe (ValueAndDerivative2 Number)) -> Rational -> Rational -> Array (Tuple Depth Approx)
 segmentDomain accuracyTarget evaluator l u =
   fromFoldable
@@ -50,10 +56,10 @@ segmentDomain accuracyTarget evaluator l u =
     state = { depth, xL, evaluatorXL, xM, evaluatorXM, xU, evaluatorXU }
 
     segments =
-      if depth < 5 then
+      if depth < minDepth then
         bisect state
       else
-        if depth >= 10 then
+        if depth >= maxDepth then
           singleton (Tuple depth x)
         else
           segmentBasedOnDerivative

--- a/src/Plot/Segments.purs
+++ b/src/Plot/Segments.purs
@@ -86,26 +86,32 @@ segmentDomain accuracyTarget evaluator l u =
     let
       w = rationalToNumber $ xM - xL
 
-      w2 = w * two
-
-      bUnstable = abs (b1 - b2) * w2 > accuracyTarget
-
-      aUnstable = abs (a1 - a2) * w2 > accuracyTarget
     in
-      if bUnstable || aUnstable then
-        bisect state
-      else
-        let
-          b = (b1 + b2) / two
+    if w <= accuracyTarget then
+      singleton (Tuple depth x)
+    else
+      let
 
-          a = (a1 + a2) / two
+        w2 = w * two
 
-          h = if abs b > one then abs ((a * w * w) / b) else abs (a * w * w)
-        in
-          if h > accuracyTarget then
-            bisect state
-          else
-            singleton (Tuple depth x)
+        bUnstable = abs (b1 - b2) * w > accuracyTarget
+
+        aUnstable = abs (a1 - a2) * w > accuracyTarget
+      in
+        if bUnstable || aUnstable then
+          bisect state
+        else
+          let
+            b = (b1 + b2) / two
+
+            a = (a1 + a2) / two
+
+            h = if abs b > one then abs ((a * w * w) / b) else abs (a * w * w)
+          in
+            if h > accuracyTarget then
+              bisect state
+            else
+              singleton (Tuple depth x)
 
   -- function not defined on either end, assume not defined on the whole segment:
   segmentBasedOnDerivative state@{ depth } x { fxL: Nothing, fxU: Nothing } = singleton (Tuple depth x)

--- a/test/Plot/Segments/SegmentDomain.purs
+++ b/test/Plot/Segments/SegmentDomain.purs
@@ -22,7 +22,7 @@ import Test.Unit.Assert (equal)
 segmentDomainTests :: TestSuite
 segmentDomainTests =
   suite "Plot.Segments - segmentDomain" do
-    test "SHOULD segment domain into 32 segments WHEN f''(x) = 0 AND accuracyTarget = 1 AND onePixel = 1 AND domain = [-1, 1]" do
+    test "SHOULD segment domain into 8 segments WHEN f''(x) = 0 AND accuracyTarget = 0.1 AND onePixel = 1 AND domain = [-1, 1]" do
       let
         -- given
         jobQueue = initialJobQueue
@@ -41,40 +41,9 @@ segmentDomainTests =
 
         -- then
         expected =
-          "(-1.0,-0.9375),"
-            <> "(-0.9375,-0.875),"
-            <> "(-0.875,-0.8125),"
-            <> "(-0.8125,-0.75),"
-            <> "(-0.75,-0.6875),"
-            <> "(-0.6875,-0.625),"
-            <> "(-0.625,-0.5625),"
-            <> "(-0.5625,-0.5),"
-            <> "(-0.5,-0.4375),"
-            <> "(-0.4375,-0.375),"
-            <> "(-0.375,-0.3125),"
-            <> "(-0.3125,-0.25),"
-            <> "(-0.25,-0.1875),"
-            <> "(-0.1875,-0.125),"
-            <> "(-0.125,-0.0625),"
-            <> "(-0.0625,0.0),"
-            <> "(0.0,0.0625),"
-            <> "(0.0625,0.125),"
-            <> "(0.125,0.1875),"
-            <> "(0.1875,0.25),"
-            <> "(0.25,0.3125),"
-            <> "(0.3125,0.375),"
-            <> "(0.375,0.4375),"
-            <> "(0.4375,0.5),"
-            <> "(0.5,0.5625),"
-            <> "(0.5625,0.625),"
-            <> "(0.625,0.6875),"
-            <> "(0.6875,0.75),"
-            <> "(0.75,0.8125),"
-            <> "(0.8125,0.875),"
-            <> "(0.875,0.9375),"
-            <> "(0.9375,1.0)"
+          "(-1.0,-0.75),(-0.75,-0.5),(-0.5,-0.25),(-0.25,0.0),(0.0,0.25),(0.25,0.5),(0.5,0.75),(0.75,1.0)"
 
-        expectedCount = 32
+        expectedCount = 8
       equal expectedCount $ length segments
       equal expected $ showSegments segments
 

--- a/test/Plot/Segments/SegmentDomain.purs
+++ b/test/Plot/Segments/SegmentDomain.purs
@@ -6,12 +6,13 @@ import Prelude
 import Data.Array (length)
 import Data.Either (Either(..))
 import Data.String (joinWith)
-import Data.Tuple (Tuple(..))
+import Data.Tuple (Tuple(..), snd)
 import Effect.Exception.Unsafe (unsafeThrow)
 import Expression.Parser (parse)
 import Expression.Simplifier (simplify)
 import Expression.Syntax (Expression)
 import IntervalArith.Approx (Approx, boundsNumber)
+import Plot.Commands (Depth)
 import Plot.JobBatcher (initialJobQueue)
 import Plot.RoughPlot (evaluateWithX)
 import Plot.Segments (segmentDomain)
@@ -77,8 +78,8 @@ segmentDomainTests =
       equal expectedCount $ length segments
       equal expected $ showSegments segments
 
-showSegments :: Array Approx -> String
-showSegments = (joinWith ",") <<< (map showSegment)
+showSegments :: Array (Tuple Depth Approx) -> String
+showSegments = (joinWith ",") <<< (map (showSegment <<< snd))
   where
   showSegment :: Approx -> String
   showSegment a = "(" <> (show l) <> "," <> (show u) <> ")"

--- a/test/TestUtils.purs
+++ b/test/TestUtils.purs
@@ -61,11 +61,11 @@ eqWithInput = assertOpWithInput (==) " == "
 leqWithInput :: forall t2. Ord t2 => Show t2 => Array String -> t2 -> t2 -> Result
 leqWithInput = assertOpWithInput (<=) " <= "
 
-accuracyTolerance :: Number
-accuracyTolerance = 0.00000000001
-
 isWithinTolerance :: Number -> Number -> Boolean
 isWithinTolerance expected actual = expected <= actual + accuracyTolerance && expected >= actual - accuracyTolerance 
+  where
+  accuracyTolerance :: Number
+  accuracyTolerance = 0.00000000001
 
 -- | Assert the actual value is approximately equal to the expected value.
 equalTolerance :: Number -> Number -> Test


### PR DESCRIPTION
# Issues
Closes #118 
Closes #120 

# Summary
- Subdivide segments if accuracy is not sufficient
- Discourage segments substantially narrower than the accuracy target.
- Fix AD integer power
- Fix Approx sqrt for intervals [0,epsilon]
- Move accuracyTolerance constant from global scope so that autocomplete would not suggest it when typing accuracyTarget
- Reduce minimum segmentation depth to 3.