### PR TITLE
Added global error handling and status indicator

### DIFF
--- a/src/Components/ExpressionInput/ExpressionInput.purs
+++ b/src/Components/ExpressionInput/ExpressionInput.purs
@@ -176,7 +176,7 @@ handleAction controller = case _ of
           H.raise (ParsedAccuracy id accuracy)
   HandleExpressionInput input -> H.modify_ _ { expressionInput = input }
   HandleAccuracyInput input -> H.modify_ _ { accuracyInput = input }
-  HandleMessage input -> H.modify_ _ { input = input, expressionInput = input.expressionText, accuracyInput = show input.accuracy }
+  HandleMessage input -> H.modify_ _ { input = input, expressionInput = input.expressionText, accuracyInput = show input.accuracy, error = Nothing }
   Status status -> do
     { id } <- H.get
     H.raise (ChangedStatus id status)

--- a/src/Components/Main/Action.purs
+++ b/src/Components/Main/Action.purs
@@ -182,7 +182,6 @@ handleExpressionPlotMessage state (RaisedExpressionInputMessage (ChangedStatus i
 handleExpressionPlotMessage state (RaisedExpressionInputMessage (ParsedAccuracy id accuracy)) = do
   clearGlobalError
   H.modify_ (_ { inProgress = true })
-  handleAction DrawPlot
   fork
   plotsOrError <- H.liftAff $ alterPlotAsync updatePlot id state.plots
   handleError (toFirstError plotsOrError)

--- a/src/Components/Main/Action.purs
+++ b/src/Components/Main/Action.purs
@@ -104,6 +104,7 @@ handleBoundsInputMessage state ResetBounds = redrawWithBounds state $ canvasSize
 
 clearAction :: forall output. State -> HalogenMain output Unit
 clearAction state = do
+  clearGlobalError
   clearBoundsOrError <- H.liftAff $ computePlotAsync state.input.size (clear state.bounds)
   handleError clearBoundsOrError
     $ \clearBounds -> do
@@ -131,6 +132,7 @@ handleCanvasMessage state (Scrolled isZoomedIn) = handleAction $ Zoom isZoomedIn
 
 handleExpressionPlotMessage :: forall output. State -> ExpressionManagerMessage -> HalogenMain output Unit
 handleExpressionPlotMessage state (RaisedExpressionInputMessage (ParsedExpression id expression text)) = do
+  clearGlobalError
   plotsOrError <- H.liftAff $ alterPlotAsync updatePlot id state.plots
   handleError (toFirstError plotsOrError)
     $ \plots -> do
@@ -176,6 +178,7 @@ handleExpressionPlotMessage state (RaisedExpressionInputMessage (ChangedStatus i
   handleAction DrawPlot
 
 handleExpressionPlotMessage state (RaisedExpressionInputMessage (ParsedAccuracy id accuracy)) = do
+  clearGlobalError
   plotsOrError <- H.liftAff $ alterPlotAsync updatePlot id state.plots
   handleError (toFirstError plotsOrError)
     $ \plots -> do
@@ -233,6 +236,7 @@ fork = forkWithDelay 0.0
 
 redrawWithDelayAndBounds :: forall output. State -> XYBounds -> HalogenMain output Unit
 redrawWithDelayAndBounds state newBounds = do
+  clearGlobalError
   if state.autoRobust then do
     clearBoundsOrError <- H.liftAff $ computePlotAsync state.input.size (clear newBounds)
     handleError clearBoundsOrError
@@ -260,6 +264,7 @@ redrawWithDelayAndBounds state newBounds = do
 
 redraw :: forall output. State -> HalogenMain output Unit
 redraw state = do
+  clearGlobalError
   clearBoundsOrError <- H.liftAff $ computePlotAsync state.input.size (clear state.bounds)
   handleError clearBoundsOrError
     $ \clearBounds -> do
@@ -276,6 +281,7 @@ redraw state = do
 
 redrawRough :: forall output. State -> HalogenMain output Unit
 redrawRough state = do
+  clearGlobalError
   clearBoundsOrError <- H.liftAff $ computePlotAsync state.input.size (clear state.bounds)
   handleError clearBoundsOrError
     $ \clearBounds -> do
@@ -311,6 +317,7 @@ redrawWithBounds state newBounds = do
 
 redrawWithoutRobustWithBounds :: forall output. State -> XYBounds -> HalogenMain output Unit
 redrawWithoutRobustWithBounds state newBounds = do
+  clearGlobalError
   plotsOrError <- mapPlots clearAddDrawRough state.plots
   handleError (toFirstError plotsOrError)
     $ \plots -> do

--- a/src/Components/Main/Main.purs
+++ b/src/Components/Main/Main.purs
@@ -64,6 +64,7 @@ mainComponent =
         , total: 0
         }
     , inProgress: false
+    , error: Nothing
     }
 
   render :: forall m. MonadAff m => MonadEffect m => State -> H.ComponentHTML Action ChildSlots m

--- a/src/Components/Main/Main.purs
+++ b/src/Components/Main/Main.purs
@@ -1,13 +1,13 @@
 module Components.Main where
 
 import Prelude
-
 import Components.BatchInput (batchInputComponent)
 import Components.BoundsInput (boundsInputComponent, canvasSizeToBounds)
 import Components.Canvas (canvasComponent, defaultCanvasSize)
 import Components.Canvas.Controller (canvasController)
 import Components.Common.Action (onClickActionEvent)
 import Components.Common.ClassName (className)
+import Components.Common.Styles (style)
 import Components.ExpressionManager (Input, expressionManagerComponent)
 import Components.Main.Action (Action(..), handleAction)
 import Components.Main.Helper (isAllRobustPlotsComplete, newPlot)
@@ -77,9 +77,6 @@ mainComponent =
             [ HH.div
                 [ className "navbar-brand mr-auto" ]
                 [ HH.text "Robust plots" ]
-            , HH.span
-                [ className $ statusBadge state ]
-                [ HH.text $ status state ]
             ]
         , HH.br_
         , HH.div
@@ -110,50 +107,59 @@ mainComponent =
                         [ HH.div
                             [ className "card-header" ]
                             [ HH.div
-                                [ className "form-inline" ]
+                                [ className "row" ]
                                 [ HH.div
-                                    [ className "pr-2" ]
+                                    [ className "form-inline" ]
                                     [ HH.div
-                                        [ className "btn-group pr-1" ]
-                                        [ HH.button
-                                            [ className "btn btn-primary"
-                                            , onClickActionEvent $ Pan Left
+                                        [ className "pr-2" ]
+                                        [ HH.div
+                                            [ className "btn-group pr-1" ]
+                                            [ HH.button
+                                                [ className "btn btn-primary"
+                                                , onClickActionEvent $ Pan Left
+                                                ]
+                                                [ HH.text "◄" ]
+                                            , HH.button
+                                                [ className "btn btn-primary"
+                                                , onClickActionEvent $ Pan Right
+                                                ]
+                                                [ HH.text "►" ]
                                             ]
-                                            [ HH.text "◄" ]
-                                        , HH.button
-                                            [ className "btn btn-primary"
-                                            , onClickActionEvent $ Pan Right
+                                        , HH.div
+                                            [ className "btn-group pr-1" ]
+                                            [ HH.button
+                                                [ className "btn btn-primary"
+                                                , onClickActionEvent $ Pan Down
+                                                ]
+                                                [ HH.text "▼" ]
+                                            , HH.button
+                                                [ className "btn btn-primary"
+                                                , onClickActionEvent $ Pan Up
+                                                ]
+                                                [ HH.text "▲" ]
                                             ]
-                                            [ HH.text "►" ]
+                                        , HH.div
+                                            [ className "btn-group" ]
+                                            [ HH.button
+                                                [ className "btn btn-primary"
+                                                , onClickActionEvent $ Zoom true
+                                                ]
+                                                [ HH.text "+" ]
+                                            , HH.button
+                                                [ className "btn btn-primary"
+                                                , onClickActionEvent $ Zoom false
+                                                ]
+                                                [ HH.text "-" ]
+                                            ]
                                         ]
-                                    , HH.div
-                                        [ className "btn-group pr-1" ]
-                                        [ HH.button
-                                            [ className "btn btn-primary"
-                                            , onClickActionEvent $ Pan Down
-                                            ]
-                                            [ HH.text "▼" ]
-                                        , HH.button
-                                            [ className "btn btn-primary"
-                                            , onClickActionEvent $ Pan Up
-                                            ]
-                                            [ HH.text "▲" ]
-                                        ]
-                                    , HH.div
-                                        [ className "btn-group" ]
-                                        [ HH.button
-                                            [ className "btn btn-primary"
-                                            , onClickActionEvent $ Zoom true
-                                            ]
-                                            [ HH.text "+" ]
-                                        , HH.button
-                                            [ className "btn btn-primary"
-                                            , onClickActionEvent $ Zoom false
-                                            ]
-                                            [ HH.text "-" ]
-                                        ]
+                                    , HH.slot _boundsInput 1 boundsInputComponent state.bounds (Just <<< HandleBoundsInput)
                                     ]
-                                , HH.slot _boundsInput 1 boundsInputComponent state.bounds (Just <<< HandleBoundsInput)
+                                , HH.div
+                                    [ className "col align-self-end" ]
+                                    [ HH.span
+                                        [ className $ statusBadge state, style "float:right" ]
+                                        [ HH.text $ status state ]
+                                    ]
                                 ]
                             ]
                         , HH.div

--- a/src/Components/Main/Main.purs
+++ b/src/Components/Main/Main.purs
@@ -1,6 +1,7 @@
 module Components.Main where
 
 import Prelude
+
 import Components.BatchInput (batchInputComponent)
 import Components.BoundsInput (boundsInputComponent, canvasSizeToBounds)
 import Components.Canvas (canvasComponent, defaultCanvasSize)
@@ -14,7 +15,8 @@ import Components.Main.Types (ChildSlots, Config, State)
 import Components.ProgressBar (progressBarComponent)
 import Constants (canvasId)
 import Control.Monad.Reader (ReaderT)
-import Data.Maybe (Maybe(..))
+import Data.Array (length)
+import Data.Maybe (Maybe(..), isJust)
 import Data.Symbol (SProxy(..))
 import Effect.Aff (Aff)
 import Effect.Aff.Class (class MonadAff)
@@ -73,8 +75,11 @@ mainComponent =
       $ [ HH.nav
             [ className "navbar navbar-expand navbar-dark bg-dark" ]
             [ HH.div
-                [ className "navbar-brand" ]
+                [ className "navbar-brand mr-auto" ]
                 [ HH.text "Robust plots" ]
+            , HH.span
+                [ className "navbar-text" ]
+                [ HH.text $ status state ]
             ]
         , HH.br_
         , HH.div
@@ -190,3 +195,11 @@ toExpressionManagerInput state =
   , allRobustDraw: isAllRobustPlotsComplete state.plots
   , inProgress: state.inProgress
   }
+
+status :: State -> String
+status state
+  | isJust state.error = "Internal error!"
+  | state.progress.index == state.progress.total && state.inProgress = "Segmenting"
+  | state.inProgress = "Computing robust enclosure"
+  | (not $ isAllRobustPlotsComplete state.plots) && 1 < length state.plots = "Some enclosures not computed"
+  | otherwise = "Ready"

--- a/src/Components/Main/Main.purs
+++ b/src/Components/Main/Main.purs
@@ -78,7 +78,7 @@ mainComponent =
                 [ className "navbar-brand mr-auto" ]
                 [ HH.text "Robust plots" ]
             , HH.span
-                [ className "navbar-text" ]
+                [ className $ statusBadge state ]
                 [ HH.text $ status state ]
             ]
         , HH.br_
@@ -195,6 +195,14 @@ toExpressionManagerInput state =
   , allRobustDraw: isAllRobustPlotsComplete state.plots
   , inProgress: state.inProgress
   }
+
+statusBadge :: State -> String
+statusBadge state
+  | isJust state.error = "badge badge-danger"
+  | state.progress.index == state.progress.total && state.inProgress = "badge badge-warning"
+  | state.inProgress = "badge badge-warning"
+  | (not $ isAllRobustPlotsComplete state.plots) && 1 < length state.plots = "badge badge-success"
+  | otherwise = "badge badge-success"
 
 status :: State -> String
 status state

--- a/src/Components/Main/Types.purs
+++ b/src/Components/Main/Types.purs
@@ -8,7 +8,9 @@ import Components.Canvas (CanvasSlot, Input)
 import Components.ExpressionManager (ExpressionManagerSlot)
 import Components.ExpressionManager.Types (ExpressionPlot)
 import Components.ProgressBar (ProgressBarSlot, Progress)
+import Data.Maybe (Maybe)
 import Draw.Commands (DrawCommand)
+import Effect.Exception (Error)
 import Types (XYBounds)
 
 type State
@@ -20,6 +22,7 @@ type State
     , autoRobust :: Boolean
     , progress :: Progress
     , inProgress :: Boolean
+    , error :: Maybe Error
     }
 
 type ChildSlots

--- a/src/Plot/JobBatcher.purs
+++ b/src/Plot/JobBatcher.purs
@@ -22,6 +22,7 @@ import Data.Set (Set, empty, insert) as S
 import Draw.Commands (DrawCommand)
 import Effect (Effect)
 import Effect.Aff (Aff, Canceler, Error, makeAff, nonCanceler)
+import Effect.Exception (try)
 import Expression.Syntax (Expression)
 import IntervalArith.Approx (Approx)
 import Misc.Array (split)
@@ -88,10 +89,12 @@ cancelAll jobQueue = cancelRunning $ jobQueue { cancelled = cancelled, queue = Q
 -- | Adds a plot with its associated `batchId` to the `Job` queue.
 -- |
 -- | Running time: `O(batchSegmentCount * (batchSegmentCount - 1))`
-addPlot :: Number -> Int -> JobQueue -> XYBounds -> Expression -> String -> Id -> Aff JobQueue
+addPlot :: Number -> Int -> JobQueue -> XYBounds -> Expression -> String -> Id -> Aff (Either Error JobQueue)
 addPlot accuracyTarget batchSegmentCount jobQueue bounds expression label batchId = do
-  segmentedPlots <- makeAff $ runSegmentRobust accuracyTarget batchSegmentCount bounds expression label
-  pure $ foldl (addJob batchId) jobQueue segmentedPlots
+  segmentedPlotsOrError <- makeAff $ runSegmentRobust accuracyTarget batchSegmentCount bounds expression label
+  case segmentedPlotsOrError of
+    Left error -> pure $ Left error
+    Right segmentedPlots -> pure $ Right $ foldl (addJob batchId) jobQueue segmentedPlots
 
 -- | Sets the `Job` at the front of the queue as running.
 -- |
@@ -102,7 +105,7 @@ setRunning jobQueue = case Q.peek jobQueue.queue of
   Just job -> jobQueue { running = pure job, queue = Q.tail jobQueue.queue }
 
 -- | Executes the `Job` at the front of the queue.
-runFirst :: Size -> Bounds -> JobQueue -> Aff (Maybe JobResult)
+runFirst :: Size -> Bounds -> JobQueue -> Aff (Maybe (Either Error JobResult))
 runFirst canvasSize bounds jobQueue = runMaybeJob (runJob canvasSize) jobQueue.cancelled maybeJob
   where
   maybeJob = Q.peek jobQueue.queue
@@ -117,9 +120,10 @@ isCancelled jobQueue id = elem id jobQueue.cancelled
 insertAll :: forall a f b. Foldable f => Ord b => (a -> b) -> f a -> S.Set b -> S.Set b
 insertAll mapper toInsert set = foldr (S.insert <<< mapper) set toInsert
 
-runSegmentRobust :: Number -> Int -> XYBounds -> Expression -> String -> (Either Error (Array PlotCommand) -> Effect Unit) -> Effect Canceler
+runSegmentRobust :: Number -> Int -> XYBounds -> Expression -> String -> (Either Error (Either Error (Array PlotCommand)) -> Effect Unit) -> Effect Canceler
 runSegmentRobust accuracyTarget batchSegmentCount bounds expression label callback = do
-  callback $ Right $ segmentRobust accuracyTarget batchSegmentCount bounds expression label
+  result <- try $ pure $ segmentRobust accuracyTarget batchSegmentCount bounds expression label
+  callback $ Right $ result
   pure nonCanceler
 
 cancelRunning :: JobQueue -> JobQueue
@@ -132,17 +136,20 @@ isRunning check jobQueue = case jobQueue.running of
   Nothing -> false
   Just job -> check job
 
-runMaybeJob :: (Job -> Aff (DrawCommand Unit)) -> S.Set Id -> Maybe Job -> Aff (Maybe JobResult)
+runMaybeJob :: (Job -> Aff (Either Error (DrawCommand Unit))) -> S.Set Id -> Maybe Job -> Aff (Maybe (Either Error JobResult))
 runMaybeJob _ _ Nothing = pure Nothing
 
 runMaybeJob runner cancelled (Just job) =
   if elem job.id cancelled then
     pure Nothing
   else do
-    drawCommands <- runner job
-    pure $ Just { job, drawCommands }
+    drawCommandsOrError <- runner job
+    case drawCommandsOrError of
+      Left error -> pure $ Just $ Left error
+      Right drawCommands -> pure $ Just $ Right { job, drawCommands }
+    
 
-runJob :: Size -> Job -> Aff (DrawCommand Unit)
+runJob :: Size -> Job -> Aff (Either Error (DrawCommand Unit))
 runJob canvasSize job = computePlotAsync canvasSize job.command
 
 addJob :: Id -> JobQueue -> PlotCommand -> JobQueue

--- a/src/Plot/PlotController.purs
+++ b/src/Plot/PlotController.purs
@@ -6,6 +6,7 @@ import Data.Either (Either(..))
 import Draw.Commands (DrawCommand)
 import Effect (Effect)
 import Effect.Aff (Aff, Canceler, Error, makeAff, nonCanceler)
+import Effect.Console (log)
 import Effect.Exception (try)
 import Plot.Commands (PlotCommand(..))
 import Plot.GridLines (clearAndDrawGridLines)
@@ -18,7 +19,9 @@ computePlotAsync canvasSize plot = makeAff $ runComputation canvasSize plot
 
 runComputation :: Size -> PlotCommand -> (Either Error (Either Error (DrawCommand Unit)) -> Effect Unit) -> Effect Canceler
 runComputation canvasSize commands callback = do
-  result <- try $ pure $ runCommand canvasSize commands
+  result <- try $ do
+    log "Computing..."
+    pure $ runCommand canvasSize commands
   callback $ Right result
   pure nonCanceler
 

--- a/src/Plot/PlotController.purs
+++ b/src/Plot/PlotController.purs
@@ -1,22 +1,25 @@
 module Plot.PlotController where
 
 import Prelude
+
 import Data.Either (Either(..))
 import Draw.Commands (DrawCommand)
 import Effect (Effect)
 import Effect.Aff (Aff, Canceler, Error, makeAff, nonCanceler)
+import Effect.Exception (try)
 import Plot.Commands (PlotCommand(..))
 import Plot.GridLines (clearAndDrawGridLines)
 import Plot.RobustPlot (drawRobustPlot)
 import Plot.RoughPlot (drawRoughPlot)
 import Types (Size)
 
-computePlotAsync :: Size -> PlotCommand -> Aff (DrawCommand Unit)
+computePlotAsync :: Size -> PlotCommand -> Aff (Either Error (DrawCommand Unit))
 computePlotAsync canvasSize plot = makeAff $ runComputation canvasSize plot
 
-runComputation :: Size -> PlotCommand -> (Either Error (DrawCommand Unit) -> Effect Unit) -> Effect Canceler
+runComputation :: Size -> PlotCommand -> (Either Error (Either Error (DrawCommand Unit)) -> Effect Unit) -> Effect Canceler
 runComputation canvasSize commands callback = do
-  callback $ Right $ runCommand canvasSize commands
+  result <- try $ pure $ runCommand canvasSize commands
+  callback $ Right result
   pure nonCanceler
 
 runCommand :: Size -> PlotCommand -> DrawCommand Unit

--- a/src/Plot/RobustPlot.purs
+++ b/src/Plot/RobustPlot.purs
@@ -1,6 +1,7 @@
 module Plot.RobustPlot where
 
 import Prelude
+
 import Data.Array (catMaybes, reverse, take)
 import Data.Bifunctor (bimap)
 import Data.Either (Either(..))
@@ -9,6 +10,7 @@ import Data.Number as Number
 import Data.Tuple (Tuple(..))
 import Draw.Actions (drawEnclosure)
 import Draw.Commands (DrawCommand)
+import Effect.Exception.Unsafe (unsafeThrow)
 import Expression.Evaluate.AutomaticDifferentiator (ValueAndDerivative, ValueAndDerivative2, evaluateDerivative, evaluateDerivative2)
 import Expression.Syntax (Expression)
 import IntervalArith.Approx (Approx, boundsA, boundsNumber, centreA, fromRationalPrec, isFinite, lowerA, toNumber, upperA)
@@ -22,7 +24,7 @@ drawRobustPlot canvasSize bounds expression domainSegments label = drawCommands
   segmentEnclosures = plotEnclosures canvasSize bounds domainSegments evaluateWithX evaluateWithX2
 
   drawCommands = drawPlot segmentEnclosures
-
+  t = unsafeThrow "Bread"
   evaluateWithX x = value
     where
     variableMap = [ Tuple "x" { value: x, derivative: one } ]

--- a/src/Plot/RobustPlot.purs
+++ b/src/Plot/RobustPlot.purs
@@ -10,7 +10,6 @@ import Data.Number as Number
 import Data.Tuple (Tuple(..), snd)
 import Draw.Actions (drawEnclosure)
 import Draw.Commands (DrawCommand)
-import Effect.Exception.Unsafe (unsafeThrow)
 import Expression.Evaluate.AutomaticDifferentiator (ValueAndDerivative, ValueAndDerivative2, evaluateDerivative, evaluateDerivative2)
 import Expression.Syntax (Expression)
 import IntervalArith.Approx (Approx, boundsA, boundsNumber, centreA, isFinite, lowerA, mBound, setMB, toNumber, unionA, upperA)


### PR DESCRIPTION
# Issues
closes #104 
closes #123 

# Summary of changes
- Added `handleError` function for handling when an error is thrown by a function, It uses a continuation function if there is no error thrown.
- Replaced `lift $ lift` with `H.liftAff`
- Added `clearGlobalError` for removing the error from the state.
- Moved `clearAddPlotCommands` and `fromPixelAccuracy` from `Plot.Helper` into `Plot.Action`
- Added the error to the state 
- Added status indicator

# Tests
N/A